### PR TITLE
Preserve empty directories

### DIFF
--- a/src/hex_tarball.erl
+++ b/src/hex_tarball.erl
@@ -390,7 +390,13 @@ add_file(Tar, Filename) when is_list(Filename) ->
         symlink ->
             ok = hex_erl_tar:add(Tar, Filename, tar_opts());
         directory ->
-            ok;
+            case file:list_dir(Filename) of
+                {ok, []} ->
+                    hex_erl_tar:add(Tar, Filename, tar_opts());
+
+                {ok, _} ->
+                    ok
+            end;
         _ ->
             Mode = FileInfo#file_info.mode,
             {ok, Contents} = file:read_file(Filename),

--- a/test/hex_tarball_tests.erl
+++ b/test/hex_tarball_tests.erl
@@ -32,8 +32,6 @@ disk_test() ->
          "unpack/src",
          "unpack/src/foo.erl"
         ] = filelib:wildcard("unpack/**/*"),
-        {ok, ["empty", "hex_metadata.config", "src"]} = file:list_dir("unpack/"),
-        {ok, ["foo.erl"]} = file:list_dir("unpack/src/"),
         {ok, <<"-module(foo).">>} = file:read_file("unpack/src/foo.erl"),
         {ok, <<"{<<\"app\">>,<<\"foo\">>}.\n{<<\"build_tool\">>,<<\"rebar3\">>}.\n{<<\"version\">>,<<\"1.0.0\">>}.\n">>} =
             file:read_file("unpack/hex_metadata.config")

--- a/test/hex_tarball_tests.erl
+++ b/test/hex_tarball_tests.erl
@@ -16,19 +16,25 @@ memory_test() ->
 
 disk_test() ->
     hex_test_helpers:in_tmp(fun() ->
-        ok = file:write_file("foo.erl", <<"-module(foo).">>),
-        ok = file:change_mode("foo.erl", 8#100644),
-        ok = file:write_file("bad.erl", <<"bad">>),
+        ok = file:make_dir("src"),
+        ok = file:make_dir("empty"),
+        ok = file:write_file("src/foo.erl", <<"-module(foo).">>),
+        ok = file:change_mode("src/foo.erl", 8#100644),
+        ok = file:write_file("src/not_whitelisted.erl", <<"">>),
 
-        %% "." - we simulate adding whole directory but we expect that ./bad.erl
-        %% is not added to tarball because it's not whitelisted
-        Files = [".", "foo.erl"],
+        Files = ["empty", "src", "src/foo.erl"],
         Metadata = #{<<"app">> => <<"foo">>, <<"version">> => <<"1.0.0">>, <<"build_tool">> => <<"rebar3">>},
         {ok, {Tarball, Checksum}} = hex_tarball:create(Metadata, Files),
-        <<"53787F9D87A09DE9A31FB2F367E75CDE92605643A982E021000A2ECAC6384B21">> = hex_tarball:format_checksum(Checksum),
+        <<"34597B7933F4533C1BAFDD2053F2FBB398CF5D979BAC9F6E1F83A106FAE4491E">> = hex_tarball:format_checksum(Checksum),
         {ok, #{checksum := Checksum, metadata := Metadata}} = hex_tarball:unpack(Tarball, "unpack"),
-        {ok, ["foo.erl", "hex_metadata.config"]} = file:list_dir("unpack/"),
-        {ok, <<"-module(foo).">>} = file:read_file("unpack/foo.erl"),
+        ["unpack/empty",
+         "unpack/hex_metadata.config",
+         "unpack/src",
+         "unpack/src/foo.erl"
+        ] = filelib:wildcard("unpack/**/*"),
+        {ok, ["empty", "hex_metadata.config", "src"]} = file:list_dir("unpack/"),
+        {ok, ["foo.erl"]} = file:list_dir("unpack/src/"),
+        {ok, <<"-module(foo).">>} = file:read_file("unpack/src/foo.erl"),
         {ok, <<"{<<\"app\">>,<<\"foo\">>}.\n{<<\"build_tool\">>,<<\"rebar3\">>}.\n{<<\"version\">>,<<\"1.0.0\">>}.\n">>} =
             file:read_file("unpack/hex_metadata.config")
     end).


### PR DESCRIPTION
In hexpm/hex#441 we've preserved directories
but we've removed that in #27.

Now, we only add directories to the tarball if they are empty.