### PR TITLE
Add fingerprint/1 and fingerprint_equal/2 to hex_repo

### DIFF
--- a/src/hex_repo.erl
+++ b/src/hex_repo.erl
@@ -10,7 +10,9 @@
     get_docs/3,
     get_docs_to_file/4,
     get_public_key/1,
-    get_hex_installs/1
+    get_hex_installs/1,
+    fingerprint/1,
+    fingerprint_equal/2
 ]).
 
 %%====================================================================
@@ -205,6 +207,64 @@ get_hex_installs(Config) ->
         Other ->
             Other
     end.
+
+%% @doc
+%% Computes a SHA256 fingerprint of a PEM-encoded public key.
+%%
+%% Returns a string in the format "SHA256:<base64>" which can be used
+%% to verify public keys out-of-band.
+%%
+%% Examples:
+%%
+%% ```
+%% > hex_repo:fingerprint(PublicKeyPem).
+%% "SHA256:abc123..."
+%% '''
+%% @end
+-spec fingerprint(binary()) -> string().
+fingerprint(PublicKeyPem) when is_binary(PublicKeyPem) ->
+    [PemEntry] = public_key:pem_decode(PublicKeyPem),
+    PublicKey = public_key:pem_entry_decode(PemEntry),
+    application:ensure_all_started(ssh),
+    ssh:hostkey_fingerprint(sha256, PublicKey).
+
+%% @doc
+%% Compares a PEM-encoded public key against an expected fingerprint.
+%%
+%% Uses constant-time comparison to prevent timing attacks.
+%%
+%% Examples:
+%%
+%% ```
+%% > hex_repo:fingerprint_equal(PublicKeyPem, "SHA256:abc123...").
+%% true
+%% '''
+%% @end
+-spec fingerprint_equal(binary(), string()) -> boolean().
+fingerprint_equal(PublicKeyPem, ExpectedFingerprint) when is_binary(PublicKeyPem) ->
+    ActualFingerprint = fingerprint(PublicKeyPem),
+    constant_time_compare(
+        list_to_binary(ActualFingerprint),
+        list_to_binary(ExpectedFingerprint)
+    ).
+
+%% @private
+%% Constant-time comparison to prevent timing attacks.
+%% Uses crypto:hash_equals/2 on OTP 25+, falls back to manual comparison on older versions.
+-if(?OTP_RELEASE >= 25).
+constant_time_compare(A, B) ->
+    crypto:hash_equals(A, B).
+-else.
+constant_time_compare(A, B) when byte_size(A) =:= byte_size(B) ->
+    constant_time_compare(A, B, 0);
+constant_time_compare(_, _) ->
+    false.
+
+constant_time_compare(<<X, RestA/binary>>, <<Y, RestB/binary>>, Acc) ->
+    constant_time_compare(RestA, RestB, Acc bor (X bxor Y));
+constant_time_compare(<<>>, <<>>, Acc) ->
+    Acc =:= 0.
+-endif.
 
 %%====================================================================
 %% Internal functions

--- a/test/hex_repo_SUITE.erl
+++ b/test/hex_repo_SUITE.erl
@@ -29,7 +29,9 @@ all() ->
         get_docs_to_file_test,
         get_hex_installs_test,
         get_public_key_test,
-        repo_org_not_set
+        repo_org_not_set,
+        fingerprint_test,
+        fingerprint_equal_test
     ].
 
 get_names_test(_Config) ->
@@ -132,4 +134,38 @@ repo_org_not_set(_Config) ->
         lists:filter(fun(#{version := Version}) -> Version == <<"1.0.0">> end, Releases),
 
     {ok, {403, _, _}} = hex_repo:get_package(Config, <<"nonexisting">>),
+    ok.
+
+fingerprint_test(_Config) ->
+    PublicKeyPem = <<
+        "-----BEGIN PUBLIC KEY-----\n"
+        "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEApqREcFDt5vV21JVe2QNB\n"
+        "Edvzk6w36aNFhVGWN5toNJRjRJ6m4hIuG4KaXtDWVLjnvct6MYMfqhC79HAGwyF+\n"
+        "IqR6Q6a5bbFSsImgBJwz1oadoVKD6ZNetAuCIK84cjMrEFRkELtEIPNHblCzUkkM\n"
+        "3rS9+DPlnfG8hBvGi6tvQIuZmXGCxF/73hU0/MyGhbmEjIKRtG6b0sJYKelRLTPW\n"
+        "XgK7s5pESgiwf2YC/2MGDXjAJfpfCd0RpLdvd4eRiXtVlE9qO9bND94E7PgQ/xqZ\n"
+        "J1i2xWFndWa6nfFnRxZmCStCOZWYYPlaxr+FZceFbpMwzTNs4g3d4tLNUcbKAIH4\n"
+        "0wIDAQAB\n"
+        "-----END PUBLIC KEY-----\n"
+    >>,
+    ExpectedFingerprint = "SHA256:O1LOYhHFW4kcrblKAxROaDEzLD8bn1seWbe5tq8TRsk",
+    ?assertEqual(ExpectedFingerprint, hex_repo:fingerprint(PublicKeyPem)),
+    ok.
+
+fingerprint_equal_test(_Config) ->
+    PublicKeyPem = <<
+        "-----BEGIN PUBLIC KEY-----\n"
+        "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEApqREcFDt5vV21JVe2QNB\n"
+        "Edvzk6w36aNFhVGWN5toNJRjRJ6m4hIuG4KaXtDWVLjnvct6MYMfqhC79HAGwyF+\n"
+        "IqR6Q6a5bbFSsImgBJwz1oadoVKD6ZNetAuCIK84cjMrEFRkELtEIPNHblCzUkkM\n"
+        "3rS9+DPlnfG8hBvGi6tvQIuZmXGCxF/73hU0/MyGhbmEjIKRtG6b0sJYKelRLTPW\n"
+        "XgK7s5pESgiwf2YC/2MGDXjAJfpfCd0RpLdvd4eRiXtVlE9qO9bND94E7PgQ/xqZ\n"
+        "J1i2xWFndWa6nfFnRxZmCStCOZWYYPlaxr+FZceFbpMwzTNs4g3d4tLNUcbKAIH4\n"
+        "0wIDAQAB\n"
+        "-----END PUBLIC KEY-----\n"
+    >>,
+    CorrectFingerprint = "SHA256:O1LOYhHFW4kcrblKAxROaDEzLD8bn1seWbe5tq8TRsk",
+    WrongFingerprint = "SHA256:WrongFingerprint123456789012345678901234567",
+    ?assert(hex_repo:fingerprint_equal(PublicKeyPem, CorrectFingerprint)),
+    ?assertNot(hex_repo:fingerprint_equal(PublicKeyPem, WrongFingerprint)),
     ok.


### PR DESCRIPTION
These functions allow computing and verifying SHA256 fingerprints of PEM-encoded public keys, useful for out-of-band verification when configuring repositories.

fingerprint_equal/2 uses crypto:hash_equals/2 for constant-time comparison to prevent timing attacks.