### PR TITLE
Introduce `hex_auth` module

### DIFF
--- a/src/hex_api.erl
+++ b/src/hex_api.erl
@@ -17,7 +17,8 @@
 -export_type([response/0]).
 
 -type response() :: {ok, {hex_http:status(), hex_http:headers(), body() | nil}} | {error, term()}.
--type body() :: [body()] | #{binary() => body() | binary()}.
+-type body() :: #{binary() => value()} | [#{binary() => value()}].
+-type value() :: binary() | boolean() | nil | number() | [value()] | #{binary() => value()}.
 
 %% @private
 get(Config, Path) ->

--- a/src/hex_api_oauth.erl
+++ b/src/hex_api_oauth.erl
@@ -146,7 +146,7 @@ device_auth_flow(Config, ClientId, Scope, PromptUser, Opts) ->
                 <<"user_code">> := UserCode,
                 <<"verification_uri_complete">> := VerificationUri,
                 <<"expires_in">> := ExpiresIn,
-                <<"interval">> := Interval
+                <<"interval">> := IntervalSeconds
             } = DeviceResponse,
             ok = PromptUser(VerificationUri, UserCode),
             OpenBrowser = proplists:get_value(open_browser, Opts, false),
@@ -154,8 +154,8 @@ device_auth_flow(Config, ClientId, Scope, PromptUser, Opts) ->
                 true -> open_browser(VerificationUri);
                 false -> ok
             end,
-            Deadline = erlang:system_time(second) + ExpiresIn,
-            poll_for_token_loop(Config, ClientId, DeviceCode, Interval, Deadline);
+            ExpiresAt = erlang:system_time(second) + ExpiresIn,
+            poll_for_token_loop(Config, ClientId, DeviceCode, IntervalSeconds, ExpiresAt);
         {ok, {Status, _, Body}} ->
             {error, {device_auth_failed, Status, Body}};
         {error, Reason} ->
@@ -163,13 +163,13 @@ device_auth_flow(Config, ClientId, Scope, PromptUser, Opts) ->
     end.
 
 %% @private
-poll_for_token_loop(Config, ClientId, DeviceCode, Interval, Deadline) ->
+poll_for_token_loop(Config, ClientId, DeviceCode, IntervalSeconds, ExpiresAt) ->
     Now = erlang:system_time(second),
-    case Now >= Deadline of
+    case Now >= ExpiresAt of
         true ->
             {error, timeout};
         false ->
-            timer:sleep(Interval * 1000),
+            timer:sleep(IntervalSeconds * 1000),
             case poll_device_token(Config, ClientId, DeviceCode) of
                 {ok, {200, _, TokenResponse}} when is_map(TokenResponse) ->
                     #{
@@ -177,17 +177,19 @@ poll_for_token_loop(Config, ClientId, DeviceCode, Interval, Deadline) ->
                         <<"expires_in">> := ExpiresIn
                     } = TokenResponse,
                     RefreshToken = maps:get(<<"refresh_token">>, TokenResponse, undefined),
-                    ExpiresAt = erlang:system_time(second) + ExpiresIn,
+                    TokenExpiresAt = erlang:system_time(second) + ExpiresIn,
                     {ok, #{
                         access_token => AccessToken,
                         refresh_token => RefreshToken,
-                        expires_at => ExpiresAt
+                        expires_at => TokenExpiresAt
                     }};
                 {ok, {400, _, #{<<"error">> := <<"authorization_pending">>}}} ->
-                    poll_for_token_loop(Config, ClientId, DeviceCode, Interval, Deadline);
+                    poll_for_token_loop(Config, ClientId, DeviceCode, IntervalSeconds, ExpiresAt);
                 {ok, {400, _, #{<<"error">> := <<"slow_down">>}}} ->
                     %% Increase polling interval as requested by server
-                    poll_for_token_loop(Config, ClientId, DeviceCode, Interval + 5, Deadline);
+                    poll_for_token_loop(
+                        Config, ClientId, DeviceCode, IntervalSeconds + 5, ExpiresAt
+                    );
                 {ok, {400, _, #{<<"error">> := <<"expired_token">>}}} ->
                     {error, timeout};
                 {ok, {Status, _, #{<<"error">> := <<"access_denied">>} = Body}} ->

--- a/src/hex_api_oauth.erl
+++ b/src/hex_api_oauth.erl
@@ -4,12 +4,29 @@
 -export([
     device_authorization/3,
     device_authorization/4,
+    device_auth_flow/4,
+    device_auth_flow/5,
     poll_device_token/3,
     refresh_token/3,
     revoke_token/3,
     client_credentials_token/4,
     client_credentials_token/5
 ]).
+
+-export_type([oauth_tokens/0, device_auth_error/0]).
+
+-type oauth_tokens() :: #{
+    access_token := binary(),
+    refresh_token => binary() | undefined,
+    expires_at := integer()
+}.
+
+-type device_auth_error() ::
+    timeout
+    | {access_denied, Status :: non_neg_integer(), Body :: term()}
+    | {device_auth_failed, Status :: non_neg_integer(), Body :: term()}
+    | {poll_failed, Status :: non_neg_integer(), Body :: term()}
+    | term().
 
 %% @doc
 %% Initiates the OAuth device authorization flow.
@@ -26,7 +43,7 @@ device_authorization(Config, ClientId, Scope) ->
 %% Returns device code, user code, and verification URIs for user authentication.
 %%
 %% Options:
-%%   * `name' - A name to identify the token (e.g., hostname of the device)
+%%   * `name' - A name to identify the token (defaults to the machine's hostname)
 %%
 %% Examples:
 %%
@@ -49,16 +66,138 @@ device_authorization(Config, ClientId, Scope) ->
     hex_api:response().
 device_authorization(Config, ClientId, Scope, Opts) ->
     Path = <<"oauth/device_authorization">>,
-    Params0 = #{
-        <<"client_id">> => ClientId,
-        <<"scope">> => Scope
-    },
-    Params =
+    Name =
         case proplists:get_value(name, Opts) of
-            undefined -> Params0;
-            Name -> Params0#{<<"name">> => Name}
+            undefined -> get_hostname();
+            N -> N
         end,
+    Params = #{
+        <<"client_id">> => ClientId,
+        <<"scope">> => Scope,
+        <<"name">> => Name
+    },
     hex_api:post(Config, Path, Params).
+
+%% @doc
+%% Runs the complete OAuth device authorization flow.
+%%
+%% @see device_auth_flow/5
+%% @end
+-spec device_auth_flow(
+    hex_core:config(),
+    ClientId :: binary(),
+    Scope :: binary(),
+    PromptUser :: fun((VerificationUri :: binary(), UserCode :: binary()) -> ok)
+) -> {ok, oauth_tokens()} | {error, device_auth_error()}.
+device_auth_flow(Config, ClientId, Scope, PromptUser) ->
+    device_auth_flow(Config, ClientId, Scope, PromptUser, []).
+
+%% @doc
+%% Runs the complete OAuth device authorization flow with options.
+%%
+%% This function handles the entire device authorization flow:
+%% 1. Requests a device code from the server
+%% 2. Calls `PromptUser' callback with the verification URI and user code
+%% 3. Optionally opens the browser for the user (when `open_browser' is true)
+%% 4. Polls the token endpoint until authorization completes or times out
+%%
+%% The `PromptUser' callback is responsible for displaying the verification URI
+%% and user code to the user (e.g., printing to console).
+%%
+%% Options:
+%%   * `name' - A name to identify the token (defaults to the machine's hostname)
+%%   * `open_browser' - When `true', automatically opens the browser
+%%     to the verification URI. When `false' (default), only the callback is invoked.
+%%
+%% Returns:
+%% - `{ok, Tokens}' - Authorization successful, returns access token and optional refresh token
+%% - `{error, timeout}' - Device code expired before user completed authorization
+%% - `{error, {access_denied, Status, Body}}' - User denied the authorization request
+%% - `{error, {device_auth_failed, Status, Body}}' - Initial device authorization request failed
+%% - `{error, {poll_failed, Status, Body}}' - Unexpected error during polling
+%%
+%% Examples:
+%%
+%% ```
+%% 1> Config = hex_core:default_config().
+%% 2> PromptUser = fun(Uri, Code) ->
+%%        io:format("Visit ~s and enter code: ~s~n", [Uri, Code])
+%%    end.
+%% 3> hex_api_oauth:device_auth_flow(Config, <<"cli">>, <<"api:write">>, PromptUser).
+%% {ok, #{
+%%     access_token => <<"...">>,
+%%     refresh_token => <<"...">>,
+%%     expires_at => 1234567890
+%% }}
+%% '''
+%% @end
+-spec device_auth_flow(
+    hex_core:config(),
+    ClientId :: binary(),
+    Scope :: binary(),
+    PromptUser :: fun((VerificationUri :: binary(), UserCode :: binary()) -> ok),
+    proplists:proplist()
+) -> {ok, oauth_tokens()} | {error, device_auth_error()}.
+device_auth_flow(Config, ClientId, Scope, PromptUser, Opts) ->
+    case device_authorization(Config, ClientId, Scope, Opts) of
+        {ok, {200, _, DeviceResponse}} when is_map(DeviceResponse) ->
+            #{
+                <<"device_code">> := DeviceCode,
+                <<"user_code">> := UserCode,
+                <<"verification_uri_complete">> := VerificationUri,
+                <<"expires_in">> := ExpiresIn,
+                <<"interval">> := Interval
+            } = DeviceResponse,
+            ok = PromptUser(VerificationUri, UserCode),
+            OpenBrowser = proplists:get_value(open_browser, Opts, false),
+            case OpenBrowser of
+                true -> open_browser(VerificationUri);
+                false -> ok
+            end,
+            Deadline = erlang:system_time(second) + ExpiresIn,
+            poll_for_token_loop(Config, ClientId, DeviceCode, Interval, Deadline);
+        {ok, {Status, _, Body}} ->
+            {error, {device_auth_failed, Status, Body}};
+        {error, Reason} ->
+            {error, Reason}
+    end.
+
+%% @private
+poll_for_token_loop(Config, ClientId, DeviceCode, Interval, Deadline) ->
+    Now = erlang:system_time(second),
+    case Now >= Deadline of
+        true ->
+            {error, timeout};
+        false ->
+            timer:sleep(Interval * 1000),
+            case poll_device_token(Config, ClientId, DeviceCode) of
+                {ok, {200, _, TokenResponse}} when is_map(TokenResponse) ->
+                    #{
+                        <<"access_token">> := AccessToken,
+                        <<"expires_in">> := ExpiresIn
+                    } = TokenResponse,
+                    RefreshToken = maps:get(<<"refresh_token">>, TokenResponse, undefined),
+                    ExpiresAt = erlang:system_time(second) + ExpiresIn,
+                    {ok, #{
+                        access_token => AccessToken,
+                        refresh_token => RefreshToken,
+                        expires_at => ExpiresAt
+                    }};
+                {ok, {400, _, #{<<"error">> := <<"authorization_pending">>}}} ->
+                    poll_for_token_loop(Config, ClientId, DeviceCode, Interval, Deadline);
+                {ok, {400, _, #{<<"error">> := <<"slow_down">>}}} ->
+                    %% Increase polling interval as requested by server
+                    poll_for_token_loop(Config, ClientId, DeviceCode, Interval + 5, Deadline);
+                {ok, {400, _, #{<<"error">> := <<"expired_token">>}}} ->
+                    {error, timeout};
+                {ok, {Status, _, #{<<"error">> := <<"access_denied">>} = Body}} ->
+                    {error, {access_denied, Status, Body}};
+                {ok, {Status, _, Body}} ->
+                    {error, {poll_failed, Status, Body}};
+                {error, Reason} ->
+                    {error, Reason}
+            end
+    end.
 
 %% @doc
 %% Polls the OAuth token endpoint for device authorization completion.
@@ -199,3 +338,44 @@ revoke_token(Config, ClientId, Token) ->
         <<"client_id">> => ClientId
     },
     hex_api:post(Config, Path, Params).
+
+%%====================================================================
+%% Internal functions
+%%====================================================================
+
+%% @private
+%% Open a URL in the default browser.
+%% Uses platform-specific commands: open (macOS), xdg-open (Linux), start (Windows).
+-spec open_browser(binary()) -> ok.
+open_browser(Url) when is_binary(Url) ->
+    ok = ensure_valid_http_url(Url),
+    UrlStr = binary_to_list(Url),
+    {Cmd, Args} =
+        case os:type() of
+            {unix, darwin} ->
+                {"open", [UrlStr]};
+            {unix, _} ->
+                {"xdg-open", [UrlStr]};
+            {win32, _} ->
+                {"cmd", ["/c", "start", "", UrlStr]}
+        end,
+    Port = open_port({spawn_executable, os:find_executable(Cmd)}, [{args, Args}]),
+    port_close(Port),
+    ok.
+
+%% @private
+%% Validates that a URL uses http:// or https:// scheme.
+-spec ensure_valid_http_url(binary()) -> ok.
+ensure_valid_http_url(Url) when is_binary(Url) ->
+    case uri_string:parse(Url) of
+        #{scheme := <<"https">>} -> ok;
+        #{scheme := <<"http">>} -> ok;
+        _ -> throw({invalid_url, Url})
+    end.
+
+%% @private
+%% Get the hostname of the current machine.
+-spec get_hostname() -> binary().
+get_hostname() ->
+    {ok, Hostname} = inet:gethostname(),
+    list_to_binary(Hostname).

--- a/src/hex_api_oauth.erl
+++ b/src/hex_api_oauth.erl
@@ -348,7 +348,7 @@ revoke_token(Config, ClientId, Token) ->
 %% @private
 %% Open a URL in the default browser.
 %% Uses platform-specific commands: open (macOS), xdg-open (Linux), start (Windows).
--spec open_browser(binary()) -> ok.
+-spec open_browser(binary()) -> ok | {error, browser_not_found}.
 open_browser(Url) when is_binary(Url) ->
     ok = ensure_valid_http_url(Url),
     UrlStr = binary_to_list(Url),
@@ -361,9 +361,13 @@ open_browser(Url) when is_binary(Url) ->
             {win32, _} ->
                 {"cmd", ["/c", "start", "", UrlStr]}
         end,
-    Port = open_port({spawn_executable, os:find_executable(Cmd)}, [{args, Args}]),
-    port_close(Port),
-    ok.
+    case os:find_executable(Cmd) of
+        false ->
+            {error, browser_not_found};
+        Executable ->
+            open_port({spawn_executable, Executable}, [{args, Args}]),
+            ok
+    end.
 
 %% @private
 %% Validates that a URL uses http:// or https:// scheme.

--- a/src/hex_cli_auth.erl
+++ b/src/hex_cli_auth.erl
@@ -1,0 +1,703 @@
+%% @doc
+%% Authentication handling with callback functions for build-tool-specific operations.
+%%
+%% This module provides generic authentication handling that allows both rebar3
+%% and Elixir Hex (and future build tools) to share the common auth logic while
+%% customizing prompting, persistence, and configuration retrieval.
+%%
+%% == Callbacks ==
+%%
+%% The caller provides a callbacks map with these functions (all required):
+%%
+%% ```
+%% #{
+%%     %% Auth configuration for a specific repo
+%%     get_auth_config => fun((RepoName :: binary()) ->
+%%         #{api_key => binary(),
+%%           auth_key => binary(),
+%%           oauth_exchange => boolean(),
+%%           oauth_exchange_url => binary()} | undefined),
+%%
+%%     %% Global OAuth tokens - storage and retrieval
+%%     get_oauth_tokens => fun(() -> {ok, #{access_token := binary(),
+%%                                          refresh_token => binary(),
+%%                                          expires_at := integer()}} | error),
+%%     persist_oauth_tokens => fun((Scope :: global | binary(),
+%%                                  AccessToken :: binary(),
+%%                                  RefreshToken :: binary() | undefined,
+%%                                  ExpiresAt :: integer()) -> ok),
+%%
+%%     %% User interaction
+%%     prompt_otp => fun((Message :: binary()) -> {ok, OtpCode :: binary()} | cancelled),
+%%     should_authenticate => fun((Reason :: no_credentials | token_refresh_failed) -> boolean()),
+%%
+%%     %% OAuth client configuration
+%%     get_client_id => fun(() -> binary())
+%% }
+%% '''
+%%
+%% == Auth Resolution Order ==
+%%
+%% For API calls:
+%% <ol>
+%% <li>Per-repo `api_key' from config (with optional OAuth exchange for hex.pm)</li>
+%% <li>Parent repo `api_key' (for "hexpm:org" organizations)</li>
+%% <li>Global OAuth token (refreshed if expired)</li>
+%% <li>Device auth flow (for write operations only)</li>
+%% </ol>
+%%
+%% For repo calls:
+%% <ol>
+%% <li>Per-repo `auth_key' with optional OAuth exchange (default true for hex.pm)</li>
+%% <li>Parent repo `auth_key'</li>
+%% <li>Global OAuth token</li>
+%% </ol>
+%%
+%% == OAuth Exchange ==
+%%
+%% For hex.pm URLs, `api_key' and `auth_key' are exchanged for short-lived OAuth
+%% tokens via the client credentials grant. This behavior can be controlled per-repo
+%% via the `oauth_exchange' option in the repo config (defaults to `true' for hex.pm).
+%%
+%% == Auth Context ==
+%%
+%% Internally, authentication resolution tracks context via `auth_context()':
+%% <ul>
+%% <li>`source' - Where the credentials came from (`env', `config', or `oauth')</li>
+%% <li>`has_refresh_token' - Whether token refresh is possible on 401</li>
+%% </ul>
+%%
+%% == Token Format ==
+%%
+%% OAuth access tokens are automatically prefixed with `<<"Bearer ">>' when used
+%% as `api_key' or `repo_key' in the config.
+-module(hex_cli_auth).
+
+-export([
+    with_api/4,
+    with_api/5,
+    with_repo/3,
+    with_repo/4,
+    resolve_api_auth/3,
+    resolve_repo_auth/2
+]).
+
+-export_type([
+    callbacks/0,
+    permission/0,
+    auth_error/0,
+    auth_context/0,
+    repo_auth_config/0,
+    auth_prompt_reason/0,
+    opts/0
+]).
+
+%% 5 minute buffer before expiry
+-define(EXPIRY_BUFFER_SECONDS, 300).
+
+%% Maximum OTP retry attempts
+-define(MAX_OTP_RETRIES, 3).
+
+-type permission() :: read | write.
+
+-type callbacks() :: #{
+    get_auth_config := fun((RepoName :: binary()) -> repo_auth_config() | undefined),
+    get_oauth_tokens := fun(() -> {ok, oauth_tokens()} | error),
+    persist_oauth_tokens := fun(
+        (
+            Scope :: global | binary(),
+            AccessToken :: binary(),
+            RefreshToken :: binary() | undefined,
+            ExpiresAt :: integer()
+        ) -> ok
+    ),
+    prompt_otp := fun((Message :: binary()) -> {ok, OtpCode :: binary()} | cancelled),
+    should_authenticate := fun((Reason :: auth_prompt_reason()) -> boolean()),
+    get_client_id := fun(() -> binary())
+}.
+
+-type auth_prompt_reason() ::
+    no_credentials
+    | token_refresh_failed.
+
+-type repo_auth_config() :: #{
+    api_key => binary(),
+    repo_key => binary(),
+    auth_key => binary(),
+    oauth_token => oauth_tokens()
+}.
+
+-type oauth_tokens() :: #{
+    access_token := binary(),
+    refresh_token => binary(),
+    expires_at := integer()
+}.
+
+-type auth_error() ::
+    {auth_error, no_credentials}
+    | {auth_error, otp_cancelled}
+    | {auth_error, otp_max_retries}
+    | {auth_error, token_refresh_failed}
+    | {auth_error, device_auth_timeout}
+    | {auth_error, device_auth_denied}
+    | {auth_error, oauth_exchange_failed}
+    | {auth_error, term()}.
+
+-type auth_context() :: #{
+    source => env | config | oauth,
+    has_refresh_token => boolean()
+}.
+
+-type opts() :: [
+    {optional, boolean()}
+    | {auth_inline, boolean()}
+    | {oauth_open_browser, boolean()}
+].
+
+%%====================================================================
+%% API functions
+%%====================================================================
+
+%% @doc
+%% Execute a function with API authentication.
+%%
+%% Equivalent to `with_api(Callbacks, Permission, Config, Fun, [])'.
+%%
+%% @see with_api/5
+-spec with_api(callbacks(), permission(), hex_core:config(), fun((hex_core:config()) -> Result)) ->
+    Result | {error, auth_error()}
+when
+    Result :: term().
+with_api(Callbacks, Permission, BaseConfig, Fun) ->
+    with_api(Callbacks, Permission, BaseConfig, Fun, []).
+
+%% @doc
+%% Execute a function with API authentication.
+%%
+%% Resolves credentials in this order:
+%% <ol>
+%% <li>Per-repo `api_key' from config (with optional OAuth exchange for hex.pm)</li>
+%% <li>Parent repo `api_key' (for "hexpm:org" organizations)</li>
+%% <li>Global OAuth token (refreshed if expired)</li>
+%% <li>Device auth flow (when `should_authenticate' callback returns true)</li>
+%% </ol>
+%%
+%% On 401 responses, handles OTP prompts and token refresh automatically.
+%%
+%% The repository name is taken from the config (`repo_name' or `repo_organization').
+%%
+%% Options:
+%% <ul>
+%% <li>`optional' - When `true', if no credentials are found, executes the function
+%%     without authentication first. If the server returns 401, triggers auth
+%%     (respecting `auth_inline'). When `false' (default), missing credentials
+%%     immediately triggers the `should_authenticate' callback.</li>
+%% <li>`auth_inline' - When `true' (default), prompts the user via `should_authenticate'
+%%     callback when authentication is needed. When `false', returns
+%%     `{error, {auth_error, no_credentials}}' instead of prompting.</li>
+%% <li>`oauth_open_browser' - When `true' (default), automatically opens the browser
+%%     during device auth flow. When `false', only prints the URL for the user.</li>
+%% </ul>
+%%
+%% Example:
+%% ```
+%% hex_cli_auth:with_api(Callbacks, write, Config, fun(C) ->
+%%     hex_api_release:publish(C, Tarball)
+%% end, [{optional, false}, {auth_inline, true}]).
+%% '''
+-spec with_api(
+    callbacks(),
+    permission(),
+    hex_core:config(),
+    fun((hex_core:config()) -> Result),
+    opts()
+) ->
+    Result | {error, auth_error()}
+when
+    Result :: term().
+with_api(Callbacks, Permission, BaseConfig, Fun, Opts) ->
+    Optional = proplists:get_value(optional, Opts, false),
+    AuthInline = proplists:get_value(auth_inline, Opts, true),
+    case resolve_api_auth(Callbacks, Permission, BaseConfig) of
+        {ok, ApiKey, AuthContext} ->
+            Config = BaseConfig#{api_key => ApiKey},
+            execute_with_retry(Callbacks, Config, Fun, AuthContext, 0, undefined);
+        {error, no_auth} when Optional =:= true ->
+            %% Auth is optional, try without credentials first
+            execute_optional_with_retry(Callbacks, BaseConfig, Fun, Opts);
+        {error, no_auth} when AuthInline =:= true ->
+            %% No auth found, ask user if they want to authenticate
+            maybe_authenticate_and_retry(Callbacks, BaseConfig, Fun, no_credentials, Opts);
+        {error, no_auth} ->
+            %% auth_inline is false, just return error
+            {error, {auth_error, no_credentials}};
+        {error, _} = Error ->
+            Error
+    end.
+
+%% @doc
+%% Execute a function with repository authentication.
+%%
+%% Equivalent to `with_repo(Callbacks, Config, Fun, [])'.
+%%
+%% @see with_repo/4
+-spec with_repo(callbacks(), hex_core:config(), fun((hex_core:config()) -> Result)) ->
+    Result | {error, auth_error()}
+when
+    Result :: term().
+with_repo(Callbacks, BaseConfig, Fun) ->
+    with_repo(Callbacks, BaseConfig, Fun, []).
+
+%% @doc
+%% Execute a function with repository authentication.
+%%
+%% Resolves credentials in this order:
+%% <ol>
+%% <li>`repo_key' in config - passthrough</li>
+%% <li>`repo_key' from `get_auth_config' callback - passthrough</li>
+%% <li>`auth_key' from `get_auth_config' when `trusted' is true and `oauth_exchange' is true - exchange for OAuth token</li>
+%% <li>`auth_key' from `get_auth_config' when `trusted' is true - use directly</li>
+%% <li>Global OAuth token from `get_oauth_tokens' callback</li>
+%% <li>No auth when `optional' is true (with retry on 401)</li>
+%% <li>Prompt via `should_authenticate' when `auth_inline' is true</li>
+%% </ol>
+%%
+%% The repository name is taken from the config (`repo_name' or `repo_organization').
+%%
+%% Options:
+%% <ul>
+%% <li>`optional' - When `true' (default), proceeds without auth if none found; retries with auth on 401.</li>
+%% <li>`auth_inline' - When `true', prompts user via `should_authenticate' callback. Default is `false'.</li>
+%% <li>`oauth_open_browser' - When `true' (default), automatically opens the browser
+%%     during device auth flow. When `false', only prints the URL for the user.</li>
+%% </ul>
+%%
+%% Example:
+%% ```
+%% hex_cli_auth:with_repo(Callbacks, Config, fun(C) ->
+%%     hex_repo:get_tarball(C, <<"ecto">>, <<"3.0.0">>)
+%% end).
+%% '''
+-spec with_repo(
+    callbacks(), hex_core:config(), fun((hex_core:config()) -> Result), opts()
+) ->
+    Result | {error, auth_error()}
+when
+    Result :: term().
+with_repo(Callbacks, BaseConfig, Fun, Opts) ->
+    Optional = proplists:get_value(optional, Opts, true),
+    AuthInline = proplists:get_value(auth_inline, Opts, false),
+    case resolve_repo_auth(Callbacks, BaseConfig) of
+        {ok, RepoKey, _AuthContext} when is_binary(RepoKey) ->
+            Config = BaseConfig#{repo_key => RepoKey},
+            Fun(Config);
+        no_auth when Optional =:= true ->
+            %% Auth is optional, try without credentials first
+            execute_optional_with_retry(Callbacks, BaseConfig, Fun, Opts);
+        no_auth when AuthInline =:= true ->
+            %% No auth found, ask user if they want to authenticate
+            maybe_authenticate_and_retry(Callbacks, BaseConfig, Fun, no_credentials, Opts);
+        no_auth ->
+            %% auth_inline is false, return error
+            {error, {auth_error, no_credentials}};
+        {error, _} = Error ->
+            Error
+    end.
+
+%% @private
+%% Extract repository name from config.
+-spec repo_name(hex_core:config()) -> binary().
+repo_name(#{repo_name := Name, repo_organization := Org}) when is_binary(Name) and is_binary(Org) ->
+    <<Name/binary, ":", Org/binary>>;
+repo_name(#{repo_name := Name}) when is_binary(Name) -> Name;
+repo_name(_) ->
+    <<"hexpm">>.
+
+%% @private
+%% Ask user if they want to authenticate, and if yes, initiate device auth.
+maybe_authenticate_and_retry(Callbacks, BaseConfig, Fun, Reason, Opts) ->
+    case call_callback(Callbacks, should_authenticate, [Reason]) of
+        true ->
+            case device_auth(Callbacks, BaseConfig, <<"api repositories">>, Opts) of
+                {ok, #{access_token := Token}} ->
+                    BearerToken = <<"Bearer ", Token/binary>>,
+                    Config = BaseConfig#{api_key => BearerToken},
+                    AuthContext = #{source => oauth, has_refresh_token => true},
+                    execute_with_retry(Callbacks, Config, Fun, AuthContext, 0, undefined);
+                {error, _} = Error ->
+                    Error
+            end;
+        false ->
+            {error, {auth_error, no_credentials}}
+    end.
+
+%% @private
+%% Execute function without auth, but retry with auth if we get a 401.
+execute_optional_with_retry(Callbacks, BaseConfig, Fun, Opts) ->
+    AuthInline = proplists:get_value(auth_inline, Opts, true),
+    case Fun(BaseConfig) of
+        {ok, {401, _Headers, _Body}} when AuthInline =:= true ->
+            %% Got 401, need auth - ask user if they want to authenticate
+            maybe_authenticate_and_retry(Callbacks, BaseConfig, Fun, no_credentials, Opts);
+        {ok, {401, _Headers, _Body}} ->
+            %% Got 401 but auth_inline is false, return error
+            {error, {auth_error, no_credentials}};
+        Other ->
+            Other
+    end.
+
+%%====================================================================
+%% Internal functions - Device Auth
+%%====================================================================
+
+%% @private
+%% Initiate OAuth device authorization flow.
+%% Prompts user, optionally opens the browser for user authentication,
+%% polls for token completion, and persists tokens via callback on success.
+-spec device_auth(callbacks(), hex_core:config(), binary(), opts()) ->
+    {ok, oauth_tokens()} | {error, auth_error()}.
+device_auth(Callbacks, Config, Scope, Opts) ->
+    ClientId = call_callback(Callbacks, get_client_id, []),
+    OpenBrowser = proplists:get_value(oauth_open_browser, Opts, true),
+    PromptUser = fun(VerificationUri, UserCode) ->
+        io:format("Open ~ts in your browser and enter code: ~ts~n", [VerificationUri, UserCode])
+    end,
+    FlowOpts = [{open_browser, OpenBrowser}],
+    case hex_api_oauth:device_auth_flow(Config, ClientId, Scope, PromptUser, FlowOpts) of
+        {ok, #{access_token := AccessToken, refresh_token := RefreshToken, expires_at := ExpiresAt}} ->
+            ok = call_callback(Callbacks, persist_oauth_tokens, [
+                global, AccessToken, RefreshToken, ExpiresAt
+            ]),
+            {ok, #{
+                access_token => AccessToken,
+                refresh_token => RefreshToken,
+                expires_at => ExpiresAt
+            }};
+        {error, timeout} ->
+            {error, {auth_error, device_auth_timeout}};
+        {error, {access_denied, _Status, _Body}} ->
+            {error, {auth_error, device_auth_denied}};
+        {error, {device_auth_failed, _Status, _Body} = Reason} ->
+            {error, {auth_error, Reason}};
+        {error, {poll_failed, _Status, _Body} = Reason} ->
+            {error, {auth_error, Reason}};
+        {error, Reason} ->
+            {error, {auth_error, Reason}}
+    end.
+
+%% @private
+%% Check if a token is expired (within 5 minute buffer).
+-spec is_token_expired(integer()) -> boolean().
+is_token_expired(ExpiresAt) ->
+    Now = erlang:system_time(second),
+    ExpiresAt - Now < ?EXPIRY_BUFFER_SECONDS.
+
+%%====================================================================
+%% Internal functions - Auth Resolution
+%%====================================================================
+
+%% @private
+-spec resolve_api_auth(callbacks(), permission(), hex_core:config()) ->
+    {ok, binary(), auth_context()} | {error, no_auth} | {error, auth_error()}.
+resolve_api_auth(_Callbacks, _Permission, #{api_key := ApiKey}) when is_binary(ApiKey) ->
+    %% api_key already in config, pass through directly
+    {ok, ApiKey, #{source => config, has_refresh_token => false}};
+resolve_api_auth(Callbacks, _Permission, Config) ->
+    RepoName = repo_name(Config),
+    %% 1. Check per-repo api_key
+    case call_callback(Callbacks, get_auth_config, [RepoName]) of
+        #{api_key := ApiKey} when is_binary(ApiKey) ->
+            {ok, ApiKey, #{source => config, has_refresh_token => false}};
+        _ ->
+            %% 2. Check parent repo (for "hexpm:org" organizations)
+            case get_parent_repo_key(Callbacks, RepoName, api_key) of
+                {ok, ApiKey} ->
+                    {ok, ApiKey, #{source => config, has_refresh_token => false}};
+                error ->
+                    %% 3. Try global OAuth token
+                    resolve_oauth_token_with_context(Callbacks, Config)
+            end
+    end.
+
+%% @private
+%% Resolve repo auth credentials in this order:
+%% 0. repo_key in config => passthrough
+%% 1. repo_key from get_auth_config => passthrough
+%% 2. trusted + auth_key + oauth_exchange => exchange for OAuth token
+%% 3. trusted + auth_key => use directly
+%% 4. trusted + global OAuth tokens => use those
+%% 5. Fallthrough to no_auth (handled by with_repo/4 for optional/auth_inline)
+-spec resolve_repo_auth(callbacks(), hex_core:config()) ->
+    {ok, binary(), auth_context()} | no_auth | {error, auth_error()}.
+resolve_repo_auth(_Callbacks, #{repo_key := RepoKey}) when is_binary(RepoKey) ->
+    %% repo_key already in config, pass through directly
+    {ok, RepoKey, #{source => config, has_refresh_token => false}};
+resolve_repo_auth(Callbacks, Config) ->
+    RepoName = repo_name(Config),
+    global:trans(
+        {{?MODULE, repo}, RepoName},
+        fun() ->
+            do_resolve_repo_auth(Callbacks, RepoName, RepoName, Config)
+        end,
+        [],
+        infinity
+    ).
+
+do_resolve_repo_auth(Callbacks, RepoName, LookupRepo, Config) ->
+    Trusted = maps:get(trusted, Config, false),
+    OAuthExchange = maps:get(oauth_exchange, Config, false),
+    case call_callback(Callbacks, get_auth_config, [LookupRepo]) of
+        #{repo_key := RepoKey} when is_binary(RepoKey) ->
+            %% 1. repo_key from get_auth_config => passthrough
+            {ok, RepoKey, #{source => config, has_refresh_token => false}};
+        #{oauth_token := OAuthToken, auth_key := AuthKey} when
+            is_binary(AuthKey) and OAuthExchange, Trusted
+        ->
+            %% 2. trusted + oauth_token + auth_key + oauth_exchange => use/refresh existing token
+            resolve_repo_oauth_token(Callbacks, RepoName, Config, AuthKey, OAuthToken);
+        #{auth_key := AuthKey} when is_binary(AuthKey) and OAuthExchange, Trusted ->
+            %% 3. trusted + auth_key + oauth_exchange => exchange for new OAuth token
+            exchange_for_oauth_token(Callbacks, RepoName, Config, AuthKey, <<"repositories">>);
+        #{auth_key := AuthKey} when is_binary(AuthKey), Trusted ->
+            %% 4. trusted + auth_key => use directly
+            {ok, AuthKey, #{source => config, has_refresh_token => false}};
+        _ when Trusted ->
+            %% 5. Check parent repo (for "hexpm:org" organizations)
+            case binary:split(LookupRepo, <<":">>) of
+                [ParentName, _OrgName] ->
+                    do_resolve_repo_auth(Callbacks, RepoName, ParentName, Config);
+                _ ->
+                    %% 6. trusted + global OAuth tokens => use those
+                    resolve_global_oauth_for_repo(Callbacks, Config)
+            end;
+        _ ->
+            %% 7. Not trusted, no auth
+            no_auth
+    end.
+
+%% @private
+resolve_global_oauth_for_repo(Callbacks, Config) ->
+    case resolve_oauth_token_with_context(Callbacks, Config) of
+        {ok, Token, AuthContext} ->
+            {ok, Token, AuthContext};
+        {error, no_auth} ->
+            no_auth;
+        {error, _} = Error ->
+            Error
+    end.
+
+%% @private
+%% Resolve repo OAuth token: use if valid, re-exchange if expiring.
+resolve_repo_oauth_token(Callbacks, RepoName, Config, AuthKey, #{
+    access_token := AccessToken, expires_at := ExpiresAt
+}) ->
+    case is_token_expired(ExpiresAt) of
+        false ->
+            %% Token is still valid, use it
+            BearerToken = <<"Bearer ", AccessToken/binary>>,
+            {ok, BearerToken, #{source => oauth, has_refresh_token => false}};
+        true ->
+            %% Token expired, do a new exchange
+            exchange_for_oauth_token(Callbacks, RepoName, Config, AuthKey, <<"repositories">>)
+    end.
+
+%% @private
+%% Exchange api_key/auth_key for OAuth token via client credentials grant.
+%% Persists the token with the repo name for per-repo token storage.
+exchange_for_oauth_token(Callbacks, RepoName, Config, AuthKey, Scope) ->
+    ClientId = call_callback(Callbacks, get_client_id, []),
+    ExchangeConfig =
+        case maps:get(oauth_exchange_url, Config, undefined) of
+            undefined -> Config;
+            OAuthUrl -> Config#{api_url => OAuthUrl}
+        end,
+    case hex_api_oauth:client_credentials_token(ExchangeConfig, ClientId, AuthKey, Scope) of
+        {ok, {200, _, #{<<"access_token">> := AccessToken, <<"expires_in">> := ExpiresIn}}} ->
+            ExpiresAt = erlang:system_time(second) + ExpiresIn,
+            ok = call_callback(Callbacks, persist_oauth_tokens, [
+                RepoName, AccessToken, undefined, ExpiresAt
+            ]),
+            BearerToken = <<"Bearer ", AccessToken/binary>>,
+            {ok, BearerToken, #{source => oauth, has_refresh_token => false}};
+        {ok, {_Status, _, _Body}} ->
+            {error, {auth_error, oauth_exchange_failed}};
+        {error, _} ->
+            {error, {auth_error, oauth_exchange_failed}}
+    end.
+
+%% @private
+get_parent_repo_key(Callbacks, RepoName, KeyType) ->
+    case binary:split(RepoName, <<":">>) of
+        [ParentName, _OrgName] ->
+            case call_callback(Callbacks, get_auth_config, [ParentName]) of
+                #{KeyType := Key} when is_binary(Key) ->
+                    {ok, Key};
+                _ ->
+                    error
+            end;
+        _ ->
+            error
+    end.
+
+%% @private
+%% Resolve OAuth token with global lock to prevent concurrent refresh attempts.
+resolve_oauth_token_with_context(Callbacks, Config) ->
+    global:trans(
+        {{?MODULE, token_refresh}, self()},
+        fun() ->
+            do_resolve_oauth_token_with_context(Callbacks, Config)
+        end,
+        [],
+        infinity
+    ).
+
+%% @private
+do_resolve_oauth_token_with_context(Callbacks, Config) ->
+    case call_callback(Callbacks, get_oauth_tokens, []) of
+        {ok, #{access_token := AccessToken, expires_at := ExpiresAt} = Tokens} ->
+            HasRefreshToken =
+                maps:is_key(refresh_token, Tokens) andalso
+                    is_binary(maps:get(refresh_token, Tokens)),
+            case is_token_expired(ExpiresAt) of
+                true ->
+                    maybe_refresh_token_with_context(Callbacks, Config, Tokens);
+                false ->
+                    BearerToken = <<"Bearer ", AccessToken/binary>>,
+                    {ok, BearerToken, #{source => oauth, has_refresh_token => HasRefreshToken}}
+            end;
+        error ->
+            {error, no_auth}
+    end.
+
+%% @private
+maybe_refresh_token_with_context(Callbacks, Config, #{refresh_token := RefreshToken}) when
+    is_binary(RefreshToken)
+->
+    ClientId = call_callback(Callbacks, get_client_id, []),
+    case hex_api_oauth:refresh_token(Config, ClientId, RefreshToken) of
+        {ok, {200, _, TokenResponse}} when is_map(TokenResponse) ->
+            #{
+                <<"access_token">> := NewAccessToken,
+                <<"expires_in">> := ExpiresIn
+            } = TokenResponse,
+            NewRefreshToken = maps:get(<<"refresh_token">>, TokenResponse, RefreshToken),
+            ExpiresAt = erlang:system_time(second) + ExpiresIn,
+            ok = call_callback(Callbacks, persist_oauth_tokens, [
+                global, NewAccessToken, NewRefreshToken, ExpiresAt
+            ]),
+            BearerToken = <<"Bearer ", NewAccessToken/binary>>,
+            HasRefreshToken = is_binary(NewRefreshToken),
+            {ok, BearerToken, #{source => oauth, has_refresh_token => HasRefreshToken}};
+        {ok, {_Status, _, _Body}} ->
+            {error, {auth_error, token_refresh_failed}};
+        {error, _Reason} ->
+            {error, {auth_error, token_refresh_failed}}
+    end;
+maybe_refresh_token_with_context(_Callbacks, _Config, _Tokens) ->
+    {error, {auth_error, token_refresh_failed}}.
+
+%%====================================================================
+%% Internal functions - Retry Logic
+%%====================================================================
+
+%% @private
+execute_with_retry(Callbacks, Config, Fun, AuthContext, OtpRetries, LastOtpError) ->
+    case Fun(Config) of
+        {error, otp_required} ->
+            handle_otp_retry(
+                Callbacks, Config, Fun, AuthContext, OtpRetries, <<"Enter OTP code:">>
+            );
+        {error, invalid_totp} ->
+            handle_otp_retry(
+                Callbacks,
+                Config,
+                Fun,
+                AuthContext,
+                OtpRetries,
+                <<"Invalid OTP code. Please try again:">>
+            );
+        {ok, {401, Headers, _Body}} = Response ->
+            case detect_auth_error(Headers) of
+                otp_required ->
+                    handle_otp_retry(
+                        Callbacks, Config, Fun, AuthContext, OtpRetries, <<"Enter OTP code:">>
+                    );
+                invalid_totp ->
+                    Msg =
+                        case LastOtpError of
+                            invalid_totp -> <<"Invalid OTP code. Please try again:">>;
+                            _ -> <<"Enter OTP code:">>
+                        end,
+                    handle_otp_retry(Callbacks, Config, Fun, AuthContext, OtpRetries, Msg);
+                token_expired ->
+                    handle_token_refresh_retry(Callbacks, Config, Fun, AuthContext);
+                none ->
+                    Response
+            end;
+        Other ->
+            Other
+    end.
+
+%% @private
+handle_otp_retry(_Callbacks, _Config, _Fun, _AuthContext, OtpRetries, _Message) when
+    OtpRetries >= ?MAX_OTP_RETRIES
+->
+    {error, {auth_error, otp_max_retries}};
+handle_otp_retry(Callbacks, Config, Fun, AuthContext, OtpRetries, Message) ->
+    case call_callback(Callbacks, prompt_otp, [Message]) of
+        {ok, OtpCode} ->
+            NewConfig = Config#{api_otp => OtpCode},
+            execute_with_retry(
+                Callbacks, NewConfig, Fun, AuthContext, OtpRetries + 1, invalid_totp
+            );
+        cancelled ->
+            {error, {auth_error, otp_cancelled}}
+    end.
+
+%% @private
+handle_token_refresh_retry(Callbacks, Config, Fun, AuthContext) ->
+    %% Only attempt refresh if we have a refresh token
+    case maps:get(has_refresh_token, AuthContext, false) of
+        true ->
+            case resolve_oauth_token_with_context(Callbacks, Config) of
+                {ok, NewBearerToken, NewAuthContext} ->
+                    NewConfig = Config#{api_key => NewBearerToken},
+                    execute_with_retry(Callbacks, NewConfig, Fun, NewAuthContext, 0, undefined);
+                {error, _} ->
+                    {error, {auth_error, token_refresh_failed}}
+            end;
+        false ->
+            {error, {auth_error, token_refresh_failed}}
+    end.
+
+%% @private
+-spec detect_auth_error(hex_http:headers()) -> otp_required | invalid_totp | token_expired | none.
+detect_auth_error(Headers) ->
+    case maps:get(<<"www-authenticate">>, Headers, undefined) of
+        undefined ->
+            none;
+        Value ->
+            parse_www_authenticate(Value)
+    end.
+
+%% @private
+parse_www_authenticate(Value) when is_binary(Value) ->
+    case Value of
+        <<"Bearer realm=\"hex\", error=\"totp_required\"", _/binary>> ->
+            otp_required;
+        <<"Bearer realm=\"hex\", error=\"invalid_totp\"", _/binary>> ->
+            invalid_totp;
+        <<"Bearer realm=\"hex\", error=\"token_expired\"", _/binary>> ->
+            token_expired;
+        _ ->
+            none
+    end.
+
+%%====================================================================
+%% Internal functions - Utilities
+%%====================================================================
+
+%% @private
+call_callback(Callbacks, Name, Args) ->
+    Fun = maps:get(Name, Callbacks),
+    erlang:apply(Fun, Args).

--- a/src/hex_cli_auth.erl
+++ b/src/hex_cli_auth.erl
@@ -135,6 +135,7 @@
 
 -type auth_error() ::
     {auth_error, no_credentials}
+    | {auth_error, auth_declined}
     | {auth_error, otp_cancelled}
     | {auth_error, otp_max_retries}
     | {auth_error, token_refresh_failed}
@@ -221,7 +222,7 @@ with_api(Callbacks, Permission, BaseConfig, Fun, Opts) ->
     case resolve_api_auth(Callbacks, Permission, BaseConfig) of
         {ok, ApiKey, AuthContext} ->
             Config = BaseConfig#{api_key => ApiKey},
-            execute_with_retry(Callbacks, Config, Fun, AuthContext, 0, undefined);
+            execute_with_retry(Callbacks, Config, Fun, AuthContext, 0, undefined, Opts);
         {error, no_auth} when Optional =:= true ->
             %% Auth is optional, try without credentials first
             execute_optional_with_retry(Callbacks, BaseConfig, Fun, Opts);
@@ -323,12 +324,12 @@ maybe_authenticate_and_retry(Callbacks, BaseConfig, Fun, Reason, Opts) ->
                     BearerToken = <<"Bearer ", Token/binary>>,
                     Config = BaseConfig#{api_key => BearerToken},
                     AuthContext = #{source => oauth, has_refresh_token => true},
-                    execute_with_retry(Callbacks, Config, Fun, AuthContext, 0, undefined);
+                    execute_with_retry(Callbacks, Config, Fun, AuthContext, 0, undefined, Opts);
                 {error, _} = Error ->
                     Error
             end;
         false ->
-            {error, {auth_error, no_credentials}}
+            {error, {auth_error, auth_declined}}
     end.
 
 %% @private
@@ -601,11 +602,11 @@ maybe_refresh_token_with_context(_Callbacks, _Config, _Tokens) ->
 %%====================================================================
 
 %% @private
-execute_with_retry(Callbacks, Config, Fun, AuthContext, OtpRetries, LastOtpError) ->
+execute_with_retry(Callbacks, Config, Fun, AuthContext, OtpRetries, LastOtpError, Opts) ->
     case Fun(Config) of
         {error, otp_required} ->
             handle_otp_retry(
-                Callbacks, Config, Fun, AuthContext, OtpRetries, <<"Enter OTP code:">>
+                Callbacks, Config, Fun, AuthContext, OtpRetries, <<"Enter OTP code:">>, Opts
             );
         {error, invalid_totp} ->
             handle_otp_retry(
@@ -614,13 +615,14 @@ execute_with_retry(Callbacks, Config, Fun, AuthContext, OtpRetries, LastOtpError
                 Fun,
                 AuthContext,
                 OtpRetries,
-                <<"Invalid OTP code. Please try again:">>
+                <<"Invalid OTP code. Please try again:">>,
+                Opts
             );
         {ok, {401, Headers, _Body}} = Response ->
             case detect_auth_error(Headers) of
                 otp_required ->
                     handle_otp_retry(
-                        Callbacks, Config, Fun, AuthContext, OtpRetries, <<"Enter OTP code:">>
+                        Callbacks, Config, Fun, AuthContext, OtpRetries, <<"Enter OTP code:">>, Opts
                     );
                 invalid_totp ->
                     Msg =
@@ -628,9 +630,9 @@ execute_with_retry(Callbacks, Config, Fun, AuthContext, OtpRetries, LastOtpError
                             invalid_totp -> <<"Invalid OTP code. Please try again:">>;
                             _ -> <<"Enter OTP code:">>
                         end,
-                    handle_otp_retry(Callbacks, Config, Fun, AuthContext, OtpRetries, Msg);
+                    handle_otp_retry(Callbacks, Config, Fun, AuthContext, OtpRetries, Msg, Opts);
                 token_expired ->
-                    handle_token_refresh_retry(Callbacks, Config, Fun, AuthContext);
+                    handle_token_refresh_retry(Callbacks, Config, Fun, AuthContext, Opts);
                 none ->
                     Response
             end;
@@ -639,33 +641,47 @@ execute_with_retry(Callbacks, Config, Fun, AuthContext, OtpRetries, LastOtpError
     end.
 
 %% @private
-handle_otp_retry(_Callbacks, _Config, _Fun, _AuthContext, OtpRetries, _Message) when
+handle_otp_retry(_Callbacks, _Config, _Fun, _AuthContext, OtpRetries, _Message, _Opts) when
     OtpRetries >= ?MAX_OTP_RETRIES
 ->
     {error, {auth_error, otp_max_retries}};
-handle_otp_retry(Callbacks, Config, Fun, AuthContext, OtpRetries, Message) ->
+handle_otp_retry(Callbacks, Config, Fun, AuthContext, OtpRetries, Message, Opts) ->
     case call_callback(Callbacks, prompt_otp, [Message]) of
         {ok, OtpCode} ->
             NewConfig = Config#{api_otp => OtpCode},
             execute_with_retry(
-                Callbacks, NewConfig, Fun, AuthContext, OtpRetries + 1, invalid_totp
+                Callbacks, NewConfig, Fun, AuthContext, OtpRetries + 1, invalid_totp, Opts
             );
         cancelled ->
             {error, {auth_error, otp_cancelled}}
     end.
 
 %% @private
-handle_token_refresh_retry(Callbacks, Config, Fun, AuthContext) ->
+handle_token_refresh_retry(Callbacks, Config, Fun, AuthContext, Opts) ->
     %% Only attempt refresh if we have a refresh token
     case maps:get(has_refresh_token, AuthContext, false) of
         true ->
             case resolve_oauth_token_with_context(Callbacks, Config) of
                 {ok, NewBearerToken, NewAuthContext} ->
                     NewConfig = Config#{api_key => NewBearerToken},
-                    execute_with_retry(Callbacks, NewConfig, Fun, NewAuthContext, 0, undefined);
+                    execute_with_retry(
+                        Callbacks, NewConfig, Fun, NewAuthContext, 0, undefined, Opts
+                    );
                 {error, _} ->
-                    {error, {auth_error, token_refresh_failed}}
+                    maybe_reauthenticate(Callbacks, Config, Fun, Opts)
             end;
+        false ->
+            maybe_reauthenticate(Callbacks, Config, Fun, Opts)
+    end.
+
+%% @private
+%% After token refresh failure, prompt the user to re-authenticate via device auth
+%% (only when auth_inline is true). Mirrors Hex.OAuth.reauthenticate/1.
+maybe_reauthenticate(Callbacks, Config, Fun, Opts) ->
+    AuthInline = proplists:get_value(auth_inline, Opts, true),
+    case AuthInline of
+        true ->
+            maybe_authenticate_and_retry(Callbacks, Config, Fun, token_refresh_failed, Opts);
         false ->
             {error, {auth_error, token_refresh_failed}}
     end.

--- a/src/hex_cli_auth.erl
+++ b/src/hex_cli_auth.erl
@@ -301,6 +301,9 @@ with_repo(Callbacks, BaseConfig, Fun, Opts) ->
         no_auth ->
             %% auth_inline is false, return error
             {error, {auth_error, no_credentials}};
+        {error, {auth_error, token_refresh_failed}} when Optional =:= true ->
+            %% Token refresh failed but auth is optional, fall back to no credentials
+            execute_optional_with_retry(Callbacks, BaseConfig, Fun, Opts);
         {error, _} = Error ->
             Error
     end.
@@ -436,11 +439,11 @@ resolve_repo_auth(_Callbacks, #{repo_key := RepoKey}) when is_binary(RepoKey) ->
 resolve_repo_auth(Callbacks, Config) ->
     RepoName = repo_name(Config),
     global:trans(
-        {{?MODULE, repo}, RepoName},
+        {{?MODULE, repo, RepoName}, self()},
         fun() ->
             do_resolve_repo_auth(Callbacks, RepoName, RepoName, Config)
         end,
-        [],
+        [node()],
         infinity
     ).
 
@@ -548,7 +551,7 @@ resolve_oauth_token_with_context(Callbacks, Config) ->
         fun() ->
             do_resolve_oauth_token_with_context(Callbacks, Config)
         end,
-        [],
+        [node()],
         infinity
     ).
 

--- a/src/hex_cli_auth.erl
+++ b/src/hex_cli_auth.erl
@@ -7,7 +7,8 @@
 %%
 %% == Callbacks ==
 %%
-%% The caller provides a callbacks map with these functions (all required):
+%% Callbacks are provided via the `cli_auth_callbacks' key in the config map.
+%% All callbacks are required:
 %%
 %% ```
 %% #{
@@ -74,12 +75,12 @@
 -module(hex_cli_auth).
 
 -export([
+    with_api/3,
     with_api/4,
-    with_api/5,
+    with_repo/2,
     with_repo/3,
-    with_repo/4,
-    resolve_api_auth/3,
-    resolve_repo_auth/2
+    resolve_api_auth/2,
+    resolve_repo_auth/1
 ]).
 
 -export_type([
@@ -162,15 +163,15 @@
 %% @doc
 %% Execute a function with API authentication.
 %%
-%% Equivalent to `with_api(Callbacks, Permission, Config, Fun, [])'.
+%% Equivalent to `with_api(Permission, Config, Fun, [])'.
 %%
-%% @see with_api/5
--spec with_api(callbacks(), permission(), hex_core:config(), fun((hex_core:config()) -> Result)) ->
+%% @see with_api/4
+-spec with_api(permission(), hex_core:config(), fun((hex_core:config()) -> Result)) ->
     Result | {error, auth_error()}
 when
     Result :: term().
-with_api(Callbacks, Permission, BaseConfig, Fun) ->
-    with_api(Callbacks, Permission, BaseConfig, Fun, []).
+with_api(Permission, BaseConfig, Fun) ->
+    with_api(Permission, BaseConfig, Fun, []).
 
 %% @doc
 %% Execute a function with API authentication.
@@ -187,6 +188,8 @@ with_api(Callbacks, Permission, BaseConfig, Fun) ->
 %%
 %% The repository name is taken from the config (`repo_name' or `repo_organization').
 %%
+%% Callbacks are taken from the `cli_auth_callbacks' key in the config map.
+%%
 %% Options:
 %% <ul>
 %% <li>`optional' - When `true', if no credentials are found, executes the function
@@ -202,12 +205,11 @@ with_api(Callbacks, Permission, BaseConfig, Fun) ->
 %%
 %% Example:
 %% ```
-%% hex_cli_auth:with_api(Callbacks, write, Config, fun(C) ->
+%% hex_cli_auth:with_api(write, Config, fun(C) ->
 %%     hex_api_release:publish(C, Tarball)
 %% end, [{optional, false}, {auth_inline, true}]).
 %% '''
 -spec with_api(
-    callbacks(),
     permission(),
     hex_core:config(),
     fun((hex_core:config()) -> Result),
@@ -216,19 +218,19 @@ with_api(Callbacks, Permission, BaseConfig, Fun) ->
     Result | {error, auth_error()}
 when
     Result :: term().
-with_api(Callbacks, Permission, BaseConfig, Fun, Opts) ->
+with_api(Permission, BaseConfig, Fun, Opts) ->
     Optional = proplists:get_value(optional, Opts, false),
     AuthInline = proplists:get_value(auth_inline, Opts, true),
-    case resolve_api_auth(Callbacks, Permission, BaseConfig) of
+    case resolve_api_auth(Permission, BaseConfig) of
         {ok, ApiKey, AuthContext} ->
             Config = BaseConfig#{api_key => ApiKey},
-            execute_with_retry(Callbacks, Config, Fun, AuthContext, 0, undefined, Opts);
+            execute_with_retry(Config, Fun, AuthContext, 0, undefined, Opts);
         {error, no_auth} when Optional =:= true ->
             %% Auth is optional, try without credentials first
-            execute_optional_with_retry(Callbacks, BaseConfig, Fun, Opts);
+            execute_optional_with_retry(BaseConfig, Fun, Opts);
         {error, no_auth} when AuthInline =:= true ->
             %% No auth found, ask user if they want to authenticate
-            maybe_authenticate_and_retry(Callbacks, BaseConfig, Fun, no_credentials, Opts);
+            maybe_authenticate_and_retry(BaseConfig, Fun, no_credentials, Opts);
         {error, no_auth} ->
             %% auth_inline is false, just return error
             {error, {auth_error, no_credentials}};
@@ -239,15 +241,15 @@ with_api(Callbacks, Permission, BaseConfig, Fun, Opts) ->
 %% @doc
 %% Execute a function with repository authentication.
 %%
-%% Equivalent to `with_repo(Callbacks, Config, Fun, [])'.
+%% Equivalent to `with_repo(Config, Fun, [])'.
 %%
-%% @see with_repo/4
--spec with_repo(callbacks(), hex_core:config(), fun((hex_core:config()) -> Result)) ->
+%% @see with_repo/3
+-spec with_repo(hex_core:config(), fun((hex_core:config()) -> Result)) ->
     Result | {error, auth_error()}
 when
     Result :: term().
-with_repo(Callbacks, BaseConfig, Fun) ->
-    with_repo(Callbacks, BaseConfig, Fun, []).
+with_repo(BaseConfig, Fun) ->
+    with_repo(BaseConfig, Fun, []).
 
 %% @doc
 %% Execute a function with repository authentication.
@@ -265,6 +267,8 @@ with_repo(Callbacks, BaseConfig, Fun) ->
 %%
 %% The repository name is taken from the config (`repo_name' or `repo_organization').
 %%
+%% Callbacks are taken from the `cli_auth_callbacks' key in the config map.
+%%
 %% Options:
 %% <ul>
 %% <li>`optional' - When `true' (default), proceeds without auth if none found; retries with auth on 401.</li>
@@ -275,35 +279,33 @@ with_repo(Callbacks, BaseConfig, Fun) ->
 %%
 %% Example:
 %% ```
-%% hex_cli_auth:with_repo(Callbacks, Config, fun(C) ->
+%% hex_cli_auth:with_repo(Config, fun(C) ->
 %%     hex_repo:get_tarball(C, <<"ecto">>, <<"3.0.0">>)
 %% end).
 %% '''
--spec with_repo(
-    callbacks(), hex_core:config(), fun((hex_core:config()) -> Result), opts()
-) ->
+-spec with_repo(hex_core:config(), fun((hex_core:config()) -> Result), opts()) ->
     Result | {error, auth_error()}
 when
     Result :: term().
-with_repo(Callbacks, BaseConfig, Fun, Opts) ->
+with_repo(BaseConfig, Fun, Opts) ->
     Optional = proplists:get_value(optional, Opts, true),
     AuthInline = proplists:get_value(auth_inline, Opts, false),
-    case resolve_repo_auth(Callbacks, BaseConfig) of
+    case resolve_repo_auth(BaseConfig) of
         {ok, RepoKey, _AuthContext} when is_binary(RepoKey) ->
             Config = BaseConfig#{repo_key => RepoKey},
             Fun(Config);
         no_auth when Optional =:= true ->
             %% Auth is optional, try without credentials first
-            execute_optional_with_retry(Callbacks, BaseConfig, Fun, Opts);
+            execute_optional_with_retry(BaseConfig, Fun, Opts);
         no_auth when AuthInline =:= true ->
             %% No auth found, ask user if they want to authenticate
-            maybe_authenticate_and_retry(Callbacks, BaseConfig, Fun, no_credentials, Opts);
+            maybe_authenticate_and_retry(BaseConfig, Fun, no_credentials, Opts);
         no_auth ->
             %% auth_inline is false, return error
             {error, {auth_error, no_credentials}};
         {error, {auth_error, token_refresh_failed}} when Optional =:= true ->
             %% Token refresh failed but auth is optional, fall back to no credentials
-            execute_optional_with_retry(Callbacks, BaseConfig, Fun, Opts);
+            execute_optional_with_retry(BaseConfig, Fun, Opts);
         {error, _} = Error ->
             Error
     end.
@@ -319,15 +321,15 @@ repo_name(_) ->
 
 %% @private
 %% Ask user if they want to authenticate, and if yes, initiate device auth.
-maybe_authenticate_and_retry(Callbacks, BaseConfig, Fun, Reason, Opts) ->
-    case call_callback(Callbacks, should_authenticate, [Reason]) of
+maybe_authenticate_and_retry(BaseConfig, Fun, Reason, Opts) ->
+    case call_callback(BaseConfig, should_authenticate, [Reason]) of
         true ->
-            case device_auth(Callbacks, BaseConfig, <<"api repositories">>, Opts) of
+            case device_auth(BaseConfig, <<"api repositories">>, Opts) of
                 {ok, #{access_token := Token}} ->
                     BearerToken = <<"Bearer ", Token/binary>>,
                     Config = BaseConfig#{api_key => BearerToken},
                     AuthContext = #{source => oauth, has_refresh_token => true},
-                    execute_with_retry(Callbacks, Config, Fun, AuthContext, 0, undefined, Opts);
+                    execute_with_retry(Config, Fun, AuthContext, 0, undefined, Opts);
                 {error, _} = Error ->
                     Error
             end;
@@ -337,12 +339,12 @@ maybe_authenticate_and_retry(Callbacks, BaseConfig, Fun, Reason, Opts) ->
 
 %% @private
 %% Execute function without auth, but retry with auth if we get a 401.
-execute_optional_with_retry(Callbacks, BaseConfig, Fun, Opts) ->
+execute_optional_with_retry(BaseConfig, Fun, Opts) ->
     AuthInline = proplists:get_value(auth_inline, Opts, true),
     case Fun(BaseConfig) of
         {ok, {401, _Headers, _Body}} when AuthInline =:= true ->
             %% Got 401, need auth - ask user if they want to authenticate
-            maybe_authenticate_and_retry(Callbacks, BaseConfig, Fun, no_credentials, Opts);
+            maybe_authenticate_and_retry(BaseConfig, Fun, no_credentials, Opts);
         {ok, {401, _Headers, _Body}} ->
             %% Got 401 but auth_inline is false, return error
             {error, {auth_error, no_credentials}};
@@ -358,10 +360,10 @@ execute_optional_with_retry(Callbacks, BaseConfig, Fun, Opts) ->
 %% Initiate OAuth device authorization flow.
 %% Prompts user, optionally opens the browser for user authentication,
 %% polls for token completion, and persists tokens via callback on success.
--spec device_auth(callbacks(), hex_core:config(), binary(), opts()) ->
+-spec device_auth(hex_core:config(), binary(), opts()) ->
     {ok, oauth_tokens()} | {error, auth_error()}.
-device_auth(Callbacks, Config, Scope, Opts) ->
-    ClientId = call_callback(Callbacks, get_client_id, []),
+device_auth(Config, Scope, Opts) ->
+    ClientId = call_callback(Config, get_client_id, []),
     OpenBrowser = proplists:get_value(oauth_open_browser, Opts, true),
     PromptUser = fun(VerificationUri, UserCode) ->
         io:format("Open ~ts in your browser and enter code: ~ts~n", [VerificationUri, UserCode])
@@ -369,7 +371,7 @@ device_auth(Callbacks, Config, Scope, Opts) ->
     FlowOpts = [{open_browser, OpenBrowser}],
     case hex_api_oauth:device_auth_flow(Config, ClientId, Scope, PromptUser, FlowOpts) of
         {ok, #{access_token := AccessToken, refresh_token := RefreshToken, expires_at := ExpiresAt}} ->
-            ok = call_callback(Callbacks, persist_oauth_tokens, [
+            ok = call_callback(Config, persist_oauth_tokens, [
                 global, AccessToken, RefreshToken, ExpiresAt
             ]),
             {ok, #{
@@ -401,25 +403,25 @@ is_token_expired(ExpiresAt) ->
 %%====================================================================
 
 %% @private
--spec resolve_api_auth(callbacks(), permission(), hex_core:config()) ->
+-spec resolve_api_auth(permission(), hex_core:config()) ->
     {ok, binary(), auth_context()} | {error, no_auth} | {error, auth_error()}.
-resolve_api_auth(_Callbacks, _Permission, #{api_key := ApiKey}) when is_binary(ApiKey) ->
+resolve_api_auth(_Permission, #{api_key := ApiKey}) when is_binary(ApiKey) ->
     %% api_key already in config, pass through directly
     {ok, ApiKey, #{source => config, has_refresh_token => false}};
-resolve_api_auth(Callbacks, _Permission, Config) ->
+resolve_api_auth(_Permission, Config) ->
     RepoName = repo_name(Config),
     %% 1. Check per-repo api_key
-    case call_callback(Callbacks, get_auth_config, [RepoName]) of
+    case call_callback(Config, get_auth_config, [RepoName]) of
         #{api_key := ApiKey} when is_binary(ApiKey) ->
             {ok, ApiKey, #{source => config, has_refresh_token => false}};
         _ ->
             %% 2. Check parent repo (for "hexpm:org" organizations)
-            case get_parent_repo_key(Callbacks, RepoName, api_key) of
+            case get_parent_repo_key(Config, RepoName, api_key) of
                 {ok, ApiKey} ->
                     {ok, ApiKey, #{source => config, has_refresh_token => false}};
                 error ->
                     %% 3. Try global OAuth token
-                    resolve_oauth_token_with_context(Callbacks, Config)
+                    resolve_oauth_token_with_context(Config)
             end
     end.
 
@@ -430,27 +432,27 @@ resolve_api_auth(Callbacks, _Permission, Config) ->
 %% 2. trusted + auth_key + oauth_exchange => exchange for OAuth token
 %% 3. trusted + auth_key => use directly
 %% 4. trusted + global OAuth tokens => use those
-%% 5. Fallthrough to no_auth (handled by with_repo/4 for optional/auth_inline)
--spec resolve_repo_auth(callbacks(), hex_core:config()) ->
+%% 5. Fallthrough to no_auth (handled by with_repo/3 for optional/auth_inline)
+-spec resolve_repo_auth(hex_core:config()) ->
     {ok, binary(), auth_context()} | no_auth | {error, auth_error()}.
-resolve_repo_auth(_Callbacks, #{repo_key := RepoKey}) when is_binary(RepoKey) ->
+resolve_repo_auth(#{repo_key := RepoKey}) when is_binary(RepoKey) ->
     %% repo_key already in config, pass through directly
     {ok, RepoKey, #{source => config, has_refresh_token => false}};
-resolve_repo_auth(Callbacks, Config) ->
+resolve_repo_auth(Config) ->
     RepoName = repo_name(Config),
     global:trans(
         {{?MODULE, repo, RepoName}, self()},
         fun() ->
-            do_resolve_repo_auth(Callbacks, RepoName, RepoName, Config)
+            do_resolve_repo_auth(RepoName, RepoName, Config)
         end,
         [node()],
         infinity
     ).
 
-do_resolve_repo_auth(Callbacks, RepoName, LookupRepo, Config) ->
+do_resolve_repo_auth(RepoName, LookupRepo, Config) ->
     Trusted = maps:get(trusted, Config, false),
     OAuthExchange = maps:get(oauth_exchange, Config, false),
-    case call_callback(Callbacks, get_auth_config, [LookupRepo]) of
+    case call_callback(Config, get_auth_config, [LookupRepo]) of
         #{repo_key := RepoKey} when is_binary(RepoKey) ->
             %% 1. repo_key from get_auth_config => passthrough
             {ok, RepoKey, #{source => config, has_refresh_token => false}};
@@ -458,10 +460,10 @@ do_resolve_repo_auth(Callbacks, RepoName, LookupRepo, Config) ->
             is_binary(AuthKey) and OAuthExchange, Trusted
         ->
             %% 2. trusted + oauth_token + auth_key + oauth_exchange => use/refresh existing token
-            resolve_repo_oauth_token(Callbacks, RepoName, Config, AuthKey, OAuthToken);
+            resolve_repo_oauth_token(RepoName, Config, AuthKey, OAuthToken);
         #{auth_key := AuthKey} when is_binary(AuthKey) and OAuthExchange, Trusted ->
             %% 3. trusted + auth_key + oauth_exchange => exchange for new OAuth token
-            exchange_for_oauth_token(Callbacks, RepoName, Config, AuthKey, <<"repositories">>);
+            exchange_for_oauth_token(RepoName, Config, AuthKey, <<"repositories">>);
         #{auth_key := AuthKey} when is_binary(AuthKey), Trusted ->
             %% 4. trusted + auth_key => use directly
             {ok, AuthKey, #{source => config, has_refresh_token => false}};
@@ -469,10 +471,10 @@ do_resolve_repo_auth(Callbacks, RepoName, LookupRepo, Config) ->
             %% 5. Check parent repo (for "hexpm:org" organizations)
             case binary:split(LookupRepo, <<":">>) of
                 [ParentName, _OrgName] ->
-                    do_resolve_repo_auth(Callbacks, RepoName, ParentName, Config);
+                    do_resolve_repo_auth(RepoName, ParentName, Config);
                 _ ->
                     %% 6. trusted + global OAuth tokens => use those
-                    resolve_global_oauth_for_repo(Callbacks, Config)
+                    resolve_global_oauth_for_repo(Config)
             end;
         _ ->
             %% 7. Not trusted, no auth
@@ -480,8 +482,8 @@ do_resolve_repo_auth(Callbacks, RepoName, LookupRepo, Config) ->
     end.
 
 %% @private
-resolve_global_oauth_for_repo(Callbacks, Config) ->
-    case resolve_oauth_token_with_context(Callbacks, Config) of
+resolve_global_oauth_for_repo(Config) ->
+    case resolve_oauth_token_with_context(Config) of
         {ok, Token, AuthContext} ->
             {ok, Token, AuthContext};
         {error, no_auth} ->
@@ -492,7 +494,7 @@ resolve_global_oauth_for_repo(Callbacks, Config) ->
 
 %% @private
 %% Resolve repo OAuth token: use if valid, re-exchange if expiring.
-resolve_repo_oauth_token(Callbacks, RepoName, Config, AuthKey, #{
+resolve_repo_oauth_token(RepoName, Config, AuthKey, #{
     access_token := AccessToken, expires_at := ExpiresAt
 }) ->
     case is_token_expired(ExpiresAt) of
@@ -502,14 +504,14 @@ resolve_repo_oauth_token(Callbacks, RepoName, Config, AuthKey, #{
             {ok, BearerToken, #{source => oauth, has_refresh_token => false}};
         true ->
             %% Token expired, do a new exchange
-            exchange_for_oauth_token(Callbacks, RepoName, Config, AuthKey, <<"repositories">>)
+            exchange_for_oauth_token(RepoName, Config, AuthKey, <<"repositories">>)
     end.
 
 %% @private
 %% Exchange api_key/auth_key for OAuth token via client credentials grant.
 %% Persists the token with the repo name for per-repo token storage.
-exchange_for_oauth_token(Callbacks, RepoName, Config, AuthKey, Scope) ->
-    ClientId = call_callback(Callbacks, get_client_id, []),
+exchange_for_oauth_token(RepoName, Config, AuthKey, Scope) ->
+    ClientId = call_callback(Config, get_client_id, []),
     ExchangeConfig =
         case maps:get(oauth_exchange_url, Config, undefined) of
             undefined -> Config;
@@ -518,7 +520,7 @@ exchange_for_oauth_token(Callbacks, RepoName, Config, AuthKey, Scope) ->
     case hex_api_oauth:client_credentials_token(ExchangeConfig, ClientId, AuthKey, Scope) of
         {ok, {200, _, #{<<"access_token">> := AccessToken, <<"expires_in">> := ExpiresIn}}} ->
             ExpiresAt = erlang:system_time(second) + ExpiresIn,
-            ok = call_callback(Callbacks, persist_oauth_tokens, [
+            ok = call_callback(Config, persist_oauth_tokens, [
                 RepoName, AccessToken, undefined, ExpiresAt
             ]),
             BearerToken = <<"Bearer ", AccessToken/binary>>,
@@ -530,10 +532,10 @@ exchange_for_oauth_token(Callbacks, RepoName, Config, AuthKey, Scope) ->
     end.
 
 %% @private
-get_parent_repo_key(Callbacks, RepoName, KeyType) ->
+get_parent_repo_key(Config, RepoName, KeyType) ->
     case binary:split(RepoName, <<":">>) of
         [ParentName, _OrgName] ->
-            case call_callback(Callbacks, get_auth_config, [ParentName]) of
+            case call_callback(Config, get_auth_config, [ParentName]) of
                 #{KeyType := Key} when is_binary(Key) ->
                     {ok, Key};
                 _ ->
@@ -545,26 +547,26 @@ get_parent_repo_key(Callbacks, RepoName, KeyType) ->
 
 %% @private
 %% Resolve OAuth token with global lock to prevent concurrent refresh attempts.
-resolve_oauth_token_with_context(Callbacks, Config) ->
+resolve_oauth_token_with_context(Config) ->
     global:trans(
         {{?MODULE, token_refresh}, self()},
         fun() ->
-            do_resolve_oauth_token_with_context(Callbacks, Config)
+            do_resolve_oauth_token_with_context(Config)
         end,
         [node()],
         infinity
     ).
 
 %% @private
-do_resolve_oauth_token_with_context(Callbacks, Config) ->
-    case call_callback(Callbacks, get_oauth_tokens, []) of
+do_resolve_oauth_token_with_context(Config) ->
+    case call_callback(Config, get_oauth_tokens, []) of
         {ok, #{access_token := AccessToken, expires_at := ExpiresAt} = Tokens} ->
             HasRefreshToken =
                 maps:is_key(refresh_token, Tokens) andalso
                     is_binary(maps:get(refresh_token, Tokens)),
             case is_token_expired(ExpiresAt) of
                 true ->
-                    maybe_refresh_token_with_context(Callbacks, Config, Tokens);
+                    maybe_refresh_token_with_context(Config, Tokens);
                 false ->
                     BearerToken = <<"Bearer ", AccessToken/binary>>,
                     {ok, BearerToken, #{source => oauth, has_refresh_token => HasRefreshToken}}
@@ -574,10 +576,10 @@ do_resolve_oauth_token_with_context(Callbacks, Config) ->
     end.
 
 %% @private
-maybe_refresh_token_with_context(Callbacks, Config, #{refresh_token := RefreshToken}) when
+maybe_refresh_token_with_context(Config, #{refresh_token := RefreshToken}) when
     is_binary(RefreshToken)
 ->
-    ClientId = call_callback(Callbacks, get_client_id, []),
+    ClientId = call_callback(Config, get_client_id, []),
     case hex_api_oauth:refresh_token(Config, ClientId, RefreshToken) of
         {ok, {200, _, TokenResponse}} when is_map(TokenResponse) ->
             #{
@@ -586,7 +588,7 @@ maybe_refresh_token_with_context(Callbacks, Config, #{refresh_token := RefreshTo
             } = TokenResponse,
             NewRefreshToken = maps:get(<<"refresh_token">>, TokenResponse, RefreshToken),
             ExpiresAt = erlang:system_time(second) + ExpiresIn,
-            ok = call_callback(Callbacks, persist_oauth_tokens, [
+            ok = call_callback(Config, persist_oauth_tokens, [
                 global, NewAccessToken, NewRefreshToken, ExpiresAt
             ]),
             BearerToken = <<"Bearer ", NewAccessToken/binary>>,
@@ -597,7 +599,7 @@ maybe_refresh_token_with_context(Callbacks, Config, #{refresh_token := RefreshTo
         {error, _Reason} ->
             {error, {auth_error, token_refresh_failed}}
     end;
-maybe_refresh_token_with_context(_Callbacks, _Config, _Tokens) ->
+maybe_refresh_token_with_context(_Config, _Tokens) ->
     {error, {auth_error, token_refresh_failed}}.
 
 %%====================================================================
@@ -605,15 +607,14 @@ maybe_refresh_token_with_context(_Callbacks, _Config, _Tokens) ->
 %%====================================================================
 
 %% @private
-execute_with_retry(Callbacks, Config, Fun, AuthContext, OtpRetries, LastOtpError, Opts) ->
+execute_with_retry(Config, Fun, AuthContext, OtpRetries, LastOtpError, Opts) ->
     case Fun(Config) of
         {error, otp_required} ->
             handle_otp_retry(
-                Callbacks, Config, Fun, AuthContext, OtpRetries, <<"Enter OTP code:">>, Opts
+                Config, Fun, AuthContext, OtpRetries, <<"Enter OTP code:">>, Opts
             );
         {error, invalid_totp} ->
             handle_otp_retry(
-                Callbacks,
                 Config,
                 Fun,
                 AuthContext,
@@ -625,7 +626,7 @@ execute_with_retry(Callbacks, Config, Fun, AuthContext, OtpRetries, LastOtpError
             case detect_auth_error(Headers) of
                 otp_required ->
                     handle_otp_retry(
-                        Callbacks, Config, Fun, AuthContext, OtpRetries, <<"Enter OTP code:">>, Opts
+                        Config, Fun, AuthContext, OtpRetries, <<"Enter OTP code:">>, Opts
                     );
                 invalid_totp ->
                     Msg =
@@ -633,9 +634,9 @@ execute_with_retry(Callbacks, Config, Fun, AuthContext, OtpRetries, LastOtpError
                             invalid_totp -> <<"Invalid OTP code. Please try again:">>;
                             _ -> <<"Enter OTP code:">>
                         end,
-                    handle_otp_retry(Callbacks, Config, Fun, AuthContext, OtpRetries, Msg, Opts);
+                    handle_otp_retry(Config, Fun, AuthContext, OtpRetries, Msg, Opts);
                 token_expired ->
-                    handle_token_refresh_retry(Callbacks, Config, Fun, AuthContext, Opts);
+                    handle_token_refresh_retry(Config, Fun, AuthContext, Opts);
                 none ->
                     Response
             end;
@@ -644,47 +645,47 @@ execute_with_retry(Callbacks, Config, Fun, AuthContext, OtpRetries, LastOtpError
     end.
 
 %% @private
-handle_otp_retry(_Callbacks, _Config, _Fun, _AuthContext, OtpRetries, _Message, _Opts) when
+handle_otp_retry(_Config, _Fun, _AuthContext, OtpRetries, _Message, _Opts) when
     OtpRetries >= ?MAX_OTP_RETRIES
 ->
     {error, {auth_error, otp_max_retries}};
-handle_otp_retry(Callbacks, Config, Fun, AuthContext, OtpRetries, Message, Opts) ->
-    case call_callback(Callbacks, prompt_otp, [Message]) of
+handle_otp_retry(Config, Fun, AuthContext, OtpRetries, Message, Opts) ->
+    case call_callback(Config, prompt_otp, [Message]) of
         {ok, OtpCode} ->
             NewConfig = Config#{api_otp => OtpCode},
             execute_with_retry(
-                Callbacks, NewConfig, Fun, AuthContext, OtpRetries + 1, invalid_totp, Opts
+                NewConfig, Fun, AuthContext, OtpRetries + 1, invalid_totp, Opts
             );
         cancelled ->
             {error, {auth_error, otp_cancelled}}
     end.
 
 %% @private
-handle_token_refresh_retry(Callbacks, Config, Fun, AuthContext, Opts) ->
+handle_token_refresh_retry(Config, Fun, AuthContext, Opts) ->
     %% Only attempt refresh if we have a refresh token
     case maps:get(has_refresh_token, AuthContext, false) of
         true ->
-            case resolve_oauth_token_with_context(Callbacks, Config) of
+            case resolve_oauth_token_with_context(Config) of
                 {ok, NewBearerToken, NewAuthContext} ->
                     NewConfig = Config#{api_key => NewBearerToken},
                     execute_with_retry(
-                        Callbacks, NewConfig, Fun, NewAuthContext, 0, undefined, Opts
+                        NewConfig, Fun, NewAuthContext, 0, undefined, Opts
                     );
                 {error, _} ->
-                    maybe_reauthenticate(Callbacks, Config, Fun, Opts)
+                    maybe_reauthenticate(Config, Fun, Opts)
             end;
         false ->
-            maybe_reauthenticate(Callbacks, Config, Fun, Opts)
+            maybe_reauthenticate(Config, Fun, Opts)
     end.
 
 %% @private
 %% After token refresh failure, prompt the user to re-authenticate via device auth
 %% (only when auth_inline is true). Mirrors Hex.OAuth.reauthenticate/1.
-maybe_reauthenticate(Callbacks, Config, Fun, Opts) ->
+maybe_reauthenticate(Config, Fun, Opts) ->
     AuthInline = proplists:get_value(auth_inline, Opts, true),
     case AuthInline of
         true ->
-            maybe_authenticate_and_retry(Callbacks, Config, Fun, token_refresh_failed, Opts);
+            maybe_authenticate_and_retry(Config, Fun, token_refresh_failed, Opts);
         false ->
             {error, {auth_error, token_refresh_failed}}
     end.
@@ -717,6 +718,7 @@ parse_www_authenticate(Value) when is_binary(Value) ->
 %%====================================================================
 
 %% @private
-call_callback(Callbacks, Name, Args) ->
+call_callback(Config, Name, Args) ->
+    #{cli_auth_callbacks := Callbacks} = Config,
     Fun = maps:get(Name, Callbacks),
     erlang:apply(Fun, Args).

--- a/src/hex_core.erl
+++ b/src/hex_core.erl
@@ -126,7 +126,8 @@
     metadata_fields => all | [binary()],
     trusted => boolean(),
     oauth_exchange => boolean(),
-    oauth_exchange_url => binary() | undefined
+    oauth_exchange_url => binary() | undefined,
+    cli_auth_callbacks => hex_cli_auth:callbacks() | undefined
 }.
 
 -spec default_config() -> config().
@@ -157,5 +158,6 @@ default_config() ->
         metadata_fields => all,
         trusted => true,
         oauth_exchange => true,
-        oauth_exchange_url => undefined
+        oauth_exchange_url => undefined,
+        cli_auth_callbacks => undefined
     }.

--- a/src/hex_core.erl
+++ b/src/hex_core.erl
@@ -123,7 +123,10 @@
     tarball_max_uncompressed_size => pos_integer() | infinity,
     docs_tarball_max_size => pos_integer() | infinity,
     docs_tarball_max_uncompressed_size => pos_integer() | infinity,
-    metadata_fields => all | [binary()]
+    metadata_fields => all | [binary()],
+    trusted => boolean(),
+    oauth_exchange => boolean(),
+    oauth_exchange_url => binary() | undefined
 }.
 
 -spec default_config() -> config().
@@ -151,5 +154,8 @@ default_config() ->
         tarball_max_uncompressed_size => 128 * 1024 * 1024,
         docs_tarball_max_size => 16 * 1024 * 1024,
         docs_tarball_max_uncompressed_size => 128 * 1024 * 1024,
-        metadata_fields => all
+        metadata_fields => all,
+        trusted => true,
+        oauth_exchange => true,
+        oauth_exchange_url => undefined
     }.

--- a/test/hex_api_SUITE.erl
+++ b/test/hex_api_SUITE.erl
@@ -29,6 +29,9 @@ all() ->
         auth_test,
         short_url_test,
         oauth_device_flow_test,
+        oauth_device_auth_flow_success_test,
+        oauth_device_auth_flow_denied_test,
+        oauth_device_auth_flow_timeout_test,
         oauth_refresh_token_test,
         oauth_revoke_test,
         oauth_client_credentials_test,
@@ -143,6 +146,82 @@ oauth_device_flow_test(_Config) ->
     % Test polling for token (should be pending initially)
     {ok, {400, _, PollResponse}} = hex_api_oauth:poll_device_token(?CONFIG, ClientId, DeviceCode),
     #{<<"error">> := <<"authorization_pending">>} = PollResponse,
+    ok.
+
+oauth_device_auth_flow_success_test(_Config) ->
+    ClientId = <<"cli">>,
+    Scope = <<"api:write">>,
+    Self = self(),
+    PromptUser = fun(VerificationUri, UserCode) ->
+        Self ! {prompt_called, VerificationUri, UserCode},
+        ok
+    end,
+
+    % Queue a success response for when polling happens
+    AccessToken = <<"test_access_token">>,
+    RefreshToken = <<"test_refresh_token">>,
+    SuccessPayload = #{
+        <<"access_token">> => AccessToken,
+        <<"refresh_token">> => RefreshToken,
+        <<"token_type">> => <<"Bearer">>,
+        <<"expires_in">> => 3600
+    },
+    Headers = #{<<"content-type">> => <<"application/vnd.hex+erlang; charset=utf-8">>},
+    Self !
+        {hex_http_test, oauth_device_response,
+            {ok, {200, Headers, term_to_binary(SuccessPayload)}}},
+
+    {ok, Tokens} = hex_api_oauth:device_auth_flow(?CONFIG, ClientId, Scope, PromptUser),
+
+    % Verify prompt was called
+    receive
+        {prompt_called, _Uri, _Code} -> ok
+    after 100 ->
+        error(prompt_not_called)
+    end,
+
+    % Verify tokens
+    #{access_token := AccessToken, refresh_token := RefreshToken, expires_at := ExpiresAt} = Tokens,
+    ?assert(is_integer(ExpiresAt)),
+    ?assert(ExpiresAt > erlang:system_time(second)),
+    ok.
+
+oauth_device_auth_flow_denied_test(_Config) ->
+    ClientId = <<"cli">>,
+    Scope = <<"api:write">>,
+    Self = self(),
+    PromptUser = fun(_VerificationUri, _UserCode) -> ok end,
+
+    % Queue an access denied response
+    ErrorPayload = #{
+        <<"error">> => <<"access_denied">>,
+        <<"error_description">> => <<"User denied access">>
+    },
+    Headers = #{<<"content-type">> => <<"application/vnd.hex+erlang; charset=utf-8">>},
+    Self !
+        {hex_http_test, oauth_device_response, {ok, {403, Headers, term_to_binary(ErrorPayload)}}},
+
+    {error, {access_denied, 403, _Body}} = hex_api_oauth:device_auth_flow(
+        ?CONFIG, ClientId, Scope, PromptUser
+    ),
+    ok.
+
+oauth_device_auth_flow_timeout_test(_Config) ->
+    ClientId = <<"cli">>,
+    Scope = <<"api:write">>,
+    Self = self(),
+    PromptUser = fun(_VerificationUri, _UserCode) -> ok end,
+
+    % Queue an expired token response
+    ErrorPayload = #{
+        <<"error">> => <<"expired_token">>,
+        <<"error_description">> => <<"Device code expired">>
+    },
+    Headers = #{<<"content-type">> => <<"application/vnd.hex+erlang; charset=utf-8">>},
+    Self !
+        {hex_http_test, oauth_device_response, {ok, {400, Headers, term_to_binary(ErrorPayload)}}},
+
+    {error, timeout} = hex_api_oauth:device_auth_flow(?CONFIG, ClientId, Scope, PromptUser),
     ok.
 
 oauth_refresh_token_test(_Config) ->

--- a/test/hex_cli_auth_SUITE.erl
+++ b/test/hex_cli_auth_SUITE.erl
@@ -1,0 +1,684 @@
+-module(hex_cli_auth_SUITE).
+
+-compile([export_all]).
+
+-include_lib("eunit/include/eunit.hrl").
+-include_lib("common_test/include/ct.hrl").
+
+-define(DEFAULT_HTTP_ADAPTER_CONFIG, #{profile => default}).
+
+-define(CONFIG, (hex_core:default_config())#{
+    http_adapter => {hex_http_test, ?DEFAULT_HTTP_ADAPTER_CONFIG},
+    http_user_agent_fragment => <<"(test)">>,
+    api_url => <<"https://api.test">>,
+    repo_url => <<"https://repo.test">>,
+    repo_name => <<"hexpm">>,
+    repo_public_key => ct:get_config({ssl_certs, test_pub})
+}).
+
+suite() ->
+    [{require, {ssl_certs, [test_pub, test_priv]}}].
+
+all() ->
+    [
+        %% resolve_api_auth tests
+        resolve_api_auth_config_passthrough_test,
+        resolve_api_auth_per_repo_test,
+        resolve_api_auth_parent_repo_test,
+        resolve_api_auth_oauth_test,
+        resolve_api_auth_oauth_expired_refresh_test,
+        resolve_api_auth_oauth_no_refresh_token_test,
+        resolve_api_auth_no_auth_test,
+
+        %% resolve_repo_auth tests - trusted vs untrusted
+        resolve_repo_auth_config_passthrough_test,
+        resolve_repo_auth_callback_repo_key_test,
+        resolve_repo_auth_trusted_auth_key_test,
+        resolve_repo_auth_untrusted_ignores_auth_key_test,
+        resolve_repo_auth_oauth_fallback_test,
+        resolve_repo_auth_no_auth_test,
+
+        %% resolve_repo_auth tests - token exchange
+        resolve_repo_auth_oauth_exchange_new_token_test,
+        resolve_repo_auth_oauth_exchange_existing_valid_test,
+        resolve_repo_auth_oauth_exchange_existing_expired_test,
+        resolve_repo_auth_parent_repo_auth_key_test,
+
+        %% with_api tests - OTP handling
+        with_api_otp_required_test,
+        with_api_otp_invalid_retry_test,
+        with_api_otp_cancelled_test,
+        with_api_otp_max_retries_test,
+
+        %% with_api tests - token refresh on 401
+        with_api_token_expired_refresh_test,
+
+        %% with_api tests - wrapper behavior
+        with_api_optional_test,
+        with_api_auth_inline_test,
+        with_api_device_auth_test,
+
+        %% with_repo tests - wrapper behavior
+        with_repo_optional_test,
+        with_repo_trusted_with_auth_test
+    ].
+
+%%====================================================================
+%% Test Cases - resolve_api_auth
+%%====================================================================
+
+resolve_api_auth_config_passthrough_test(_Config) ->
+    %% When api_key is already in config, it should be used directly
+    Callbacks = make_callbacks(#{}),
+    ConfigWithKey = ?CONFIG#{api_key => <<"config_api_key">>},
+
+    {ok, ApiKey, AuthContext} = hex_cli_auth:resolve_api_auth(Callbacks, read, ConfigWithKey),
+    ?assertEqual(<<"config_api_key">>, ApiKey),
+    ?assertEqual(#{source => config, has_refresh_token => false}, AuthContext),
+    ok.
+
+resolve_api_auth_per_repo_test(_Config) ->
+    %% Test per-repo api_key from callback
+    Callbacks = make_callbacks(#{
+        auth_config => #{<<"hexpm">> => #{api_key => <<"repo_api_key">>}}
+    }),
+
+    {ok, ApiKey, AuthContext} = hex_cli_auth:resolve_api_auth(Callbacks, write, ?CONFIG),
+    ?assertEqual(<<"repo_api_key">>, ApiKey),
+    ?assertEqual(#{source => config, has_refresh_token => false}, AuthContext),
+    ok.
+
+resolve_api_auth_parent_repo_test(_Config) ->
+    %% Test parent repo fallback for "hexpm:org" repos
+    Callbacks = make_callbacks(#{
+        auth_config => #{<<"hexpm">> => #{api_key => <<"parent_api_key">>}}
+    }),
+
+    {ok, ApiKey, _} = hex_cli_auth:resolve_api_auth(
+        Callbacks, write, ?CONFIG#{repo_name => <<"hexpm:myorg">>}
+    ),
+    ?assertEqual(<<"parent_api_key">>, ApiKey),
+    ok.
+
+resolve_api_auth_oauth_test(_Config) ->
+    %% Test OAuth token fallback with valid token
+    Now = erlang:system_time(second),
+    Callbacks = make_callbacks(#{
+        oauth_tokens =>
+            {ok, #{
+                access_token => <<"oauth_token">>,
+                refresh_token => <<"refresh_token">>,
+                expires_at => Now + 3600
+            }}
+    }),
+
+    {ok, ApiKey, AuthContext} = hex_cli_auth:resolve_api_auth(Callbacks, read, ?CONFIG),
+    ?assertEqual(<<"Bearer oauth_token">>, ApiKey),
+    ?assertEqual(#{source => oauth, has_refresh_token => true}, AuthContext),
+    ok.
+
+resolve_api_auth_oauth_expired_refresh_test(_Config) ->
+    %% Test OAuth token refresh when expired
+    Now = erlang:system_time(second),
+    Self = self(),
+    Callbacks = make_callbacks(#{
+        oauth_tokens =>
+            {ok, #{
+                access_token => <<"expired_token">>,
+                refresh_token => <<"refresh_token">>,
+                %% Expired
+                expires_at => Now - 100
+            }},
+        persist_oauth_tokens => fun(Scope, Access, Refresh, Expires) ->
+            Self ! {persisted, Scope, Access, Refresh, Expires},
+            ok
+        end
+    }),
+
+    {ok, ApiKey, AuthContext} = hex_cli_auth:resolve_api_auth(Callbacks, read, ?CONFIG),
+    %% Should have refreshed and got a new token
+    ?assertMatch(<<"Bearer ", _/binary>>, ApiKey),
+    ?assertEqual(#{source => oauth, has_refresh_token => true}, AuthContext),
+
+    %% Verify token was persisted
+    receive
+        {persisted, global, _NewAccess, _NewRefresh, _NewExpires} -> ok
+    after 100 ->
+        error(token_not_persisted)
+    end,
+    ok.
+
+resolve_api_auth_oauth_no_refresh_token_test(_Config) ->
+    %% Test OAuth token without refresh token
+    Now = erlang:system_time(second),
+    Callbacks = make_callbacks(#{
+        oauth_tokens =>
+            {ok, #{
+                access_token => <<"oauth_token">>,
+                expires_at => Now + 3600
+            }}
+    }),
+
+    {ok, ApiKey, AuthContext} = hex_cli_auth:resolve_api_auth(Callbacks, read, ?CONFIG),
+    ?assertEqual(<<"Bearer oauth_token">>, ApiKey),
+    ?assertEqual(#{source => oauth, has_refresh_token => false}, AuthContext),
+    ok.
+
+resolve_api_auth_no_auth_test(_Config) ->
+    %% Test when no auth is available
+    Callbacks = make_callbacks(#{
+        auth_config => #{},
+        oauth_tokens => error
+    }),
+
+    Result = hex_cli_auth:resolve_api_auth(Callbacks, read, ?CONFIG),
+    ?assertEqual({error, no_auth}, Result),
+    ok.
+
+%%====================================================================
+%% Test Cases - resolve_repo_auth
+%%====================================================================
+
+resolve_repo_auth_config_passthrough_test(_Config) ->
+    %% When repo_key is already in config, it should be used directly
+    Callbacks = make_callbacks(#{}),
+    ConfigWithKey = ?CONFIG#{repo_key => <<"config_repo_key">>},
+
+    {ok, RepoKey, AuthContext} = hex_cli_auth:resolve_repo_auth(Callbacks, ConfigWithKey),
+    ?assertEqual(<<"config_repo_key">>, RepoKey),
+    ?assertEqual(#{source => config, has_refresh_token => false}, AuthContext),
+    ok.
+
+resolve_repo_auth_callback_repo_key_test(_Config) ->
+    %% Test repo_key from get_auth_config callback
+    Callbacks = make_callbacks(#{
+        auth_config => #{<<"hexpm">> => #{repo_key => <<"callback_repo_key">>}}
+    }),
+
+    {ok, RepoKey, _} = hex_cli_auth:resolve_repo_auth(Callbacks, ?CONFIG#{trusted => true}),
+    ?assertEqual(<<"callback_repo_key">>, RepoKey),
+    ok.
+
+resolve_repo_auth_trusted_auth_key_test(_Config) ->
+    %% Test trusted + auth_key (no oauth_exchange) uses auth_key directly
+    Callbacks = make_callbacks(#{
+        auth_config => #{<<"hexpm">> => #{auth_key => <<"auth_key_value">>}}
+    }),
+
+    Config = ?CONFIG#{trusted => true, oauth_exchange => false},
+    {ok, RepoKey, _} = hex_cli_auth:resolve_repo_auth(Callbacks, Config),
+    ?assertEqual(<<"auth_key_value">>, RepoKey),
+    ok.
+
+resolve_repo_auth_untrusted_ignores_auth_key_test(_Config) ->
+    %% Test untrusted config ignores auth_key even when present
+    Callbacks = make_callbacks(#{
+        auth_config => #{<<"hexpm">> => #{auth_key => <<"auth_key_value">>}},
+        oauth_tokens => error
+    }),
+
+    Config = ?CONFIG#{trusted => false},
+    Result = hex_cli_auth:resolve_repo_auth(Callbacks, Config),
+    ?assertEqual(no_auth, Result),
+    ok.
+
+resolve_repo_auth_oauth_fallback_test(_Config) ->
+    %% Test fallback to global OAuth when trusted but no auth_key
+    Now = erlang:system_time(second),
+    Callbacks = make_callbacks(#{
+        auth_config => #{},
+        oauth_tokens =>
+            {ok, #{
+                access_token => <<"global_oauth">>,
+                expires_at => Now + 3600
+            }}
+    }),
+
+    Config = ?CONFIG#{trusted => true},
+    {ok, RepoKey, _} = hex_cli_auth:resolve_repo_auth(Callbacks, Config),
+    ?assertEqual(<<"Bearer global_oauth">>, RepoKey),
+    ok.
+
+resolve_repo_auth_no_auth_test(_Config) ->
+    %% Test no_auth when untrusted and no credentials
+    Callbacks = make_callbacks(#{
+        auth_config => #{},
+        oauth_tokens => error
+    }),
+
+    Config = ?CONFIG#{trusted => false},
+    Result = hex_cli_auth:resolve_repo_auth(Callbacks, Config),
+    ?assertEqual(no_auth, Result),
+    ok.
+
+resolve_repo_auth_oauth_exchange_new_token_test(_Config) ->
+    %% Test oauth_exchange with auth_key but no existing oauth_token
+    Self = self(),
+    Callbacks = make_callbacks(#{
+        auth_config => #{<<"hexpm">> => #{auth_key => <<"my_auth_key">>}},
+        persist_oauth_tokens => fun(Scope, Access, _Refresh, Expires) ->
+            Self ! {persisted, Scope, Access, Expires},
+            ok
+        end
+    }),
+
+    Config = ?CONFIG#{trusted => true, oauth_exchange => true},
+    {ok, RepoKey, AuthContext} = hex_cli_auth:resolve_repo_auth(Callbacks, Config),
+    ?assertMatch(<<"Bearer ", _/binary>>, RepoKey),
+    ?assertEqual(#{source => oauth, has_refresh_token => false}, AuthContext),
+
+    %% Verify token was persisted with repo name
+    receive
+        {persisted, <<"hexpm">>, _AccessToken, _ExpiresAt} -> ok
+    after 100 ->
+        error(token_not_persisted)
+    end,
+    ok.
+
+resolve_repo_auth_oauth_exchange_existing_valid_test(_Config) ->
+    %% Test oauth_exchange with existing valid oauth_token reuses it
+    Now = erlang:system_time(second),
+    Callbacks = make_callbacks(#{
+        auth_config => #{
+            <<"hexpm">> => #{
+                auth_key => <<"my_auth_key">>,
+                oauth_token => #{
+                    access_token => <<"existing_token">>,
+                    expires_at => Now + 3600
+                }
+            }
+        }
+    }),
+
+    Config = ?CONFIG#{trusted => true, oauth_exchange => true},
+    {ok, RepoKey, _} = hex_cli_auth:resolve_repo_auth(Callbacks, Config),
+    ?assertEqual(<<"Bearer existing_token">>, RepoKey),
+    ok.
+
+resolve_repo_auth_oauth_exchange_existing_expired_test(_Config) ->
+    %% Test oauth_exchange with expired oauth_token re-exchanges
+    Now = erlang:system_time(second),
+    Self = self(),
+    Callbacks = make_callbacks(#{
+        auth_config => #{
+            <<"hexpm">> => #{
+                auth_key => <<"my_auth_key">>,
+                oauth_token => #{
+                    access_token => <<"expired_token">>,
+                    expires_at => Now - 100
+                }
+            }
+        },
+        persist_oauth_tokens => fun(Scope, Access, _Refresh, Expires) ->
+            Self ! {persisted, Scope, Access, Expires},
+            ok
+        end
+    }),
+
+    Config = ?CONFIG#{trusted => true, oauth_exchange => true},
+    {ok, RepoKey, _} = hex_cli_auth:resolve_repo_auth(Callbacks, Config),
+    ?assertMatch(<<"Bearer ", _/binary>>, RepoKey),
+    ?assertNotEqual(<<"Bearer expired_token">>, RepoKey),
+
+    %% Verify new token was persisted
+    receive
+        {persisted, <<"hexpm">>, _NewAccessToken, _ExpiresAt} -> ok
+    after 100 ->
+        error(token_not_persisted)
+    end,
+    ok.
+
+resolve_repo_auth_parent_repo_auth_key_test(_Config) ->
+    %% Test trusted org repo falls back to parent repo auth_key
+    Callbacks = make_callbacks(#{
+        auth_config => #{<<"hexpm">> => #{auth_key => <<"parent_auth_key">>}}
+    }),
+
+    Config = ?CONFIG#{repo_name => <<"hexpm:myorg">>, trusted => true, oauth_exchange => false},
+    {ok, RepoKey, _} = hex_cli_auth:resolve_repo_auth(Callbacks, Config),
+    ?assertEqual(<<"parent_auth_key">>, RepoKey),
+    ok.
+
+%%====================================================================
+%% Test Cases - with_api OTP handling
+%%====================================================================
+
+with_api_otp_required_test(_Config) ->
+    %% Test OTP prompt when server returns otp_required
+    Now = erlang:system_time(second),
+    Callbacks = make_callbacks(#{
+        oauth_tokens =>
+            {ok, #{
+                access_token => <<"token">>,
+                expires_at => Now + 3600
+            }},
+        prompt_otp => fun(_Msg) -> {ok, <<"123456">>} end
+    }),
+
+    CallCount = counters:new(1, []),
+    Result = hex_cli_auth:with_api(
+        Callbacks,
+        write,
+        ?CONFIG,
+        fun(Config) ->
+            Count = counters:get(CallCount, 1),
+            counters:add(CallCount, 1, 1),
+            case Count of
+                0 ->
+                    %% First call: return 401 with otp_required
+                    {ok,
+                        {401,
+                            #{
+                                <<"www-authenticate">> =>
+                                    <<"Bearer realm=\"hex\", error=\"totp_required\"">>
+                            },
+                            <<>>}};
+                _ ->
+                    %% Second call: should have OTP, return success
+                    ?assertEqual(<<"123456">>, maps:get(api_otp, Config)),
+                    {ok, {200, #{}, <<"success">>}}
+            end
+        end
+    ),
+    ?assertEqual({ok, {200, #{}, <<"success">>}}, Result),
+    ?assertEqual(2, counters:get(CallCount, 1)),
+    ok.
+
+with_api_otp_invalid_retry_test(_Config) ->
+    %% Test OTP retry when server returns invalid_totp
+    Now = erlang:system_time(second),
+    OtpAttempts = counters:new(1, []),
+    Callbacks = make_callbacks(#{
+        oauth_tokens =>
+            {ok, #{
+                access_token => <<"token">>,
+                expires_at => Now + 3600
+            }},
+        prompt_otp => fun(_Msg) ->
+            Count = counters:get(OtpAttempts, 1),
+            counters:add(OtpAttempts, 1, 1),
+            case Count of
+                0 -> {ok, <<"wrong_otp">>};
+                _ -> {ok, <<"correct_otp">>}
+            end
+        end
+    }),
+
+    CallCount = counters:new(1, []),
+    Result = hex_cli_auth:with_api(
+        Callbacks,
+        write,
+        ?CONFIG,
+        fun(Config) ->
+            Count = counters:get(CallCount, 1),
+            counters:add(CallCount, 1, 1),
+            case Count of
+                0 ->
+                    {ok,
+                        {401,
+                            #{
+                                <<"www-authenticate">> =>
+                                    <<"Bearer realm=\"hex\", error=\"totp_required\"">>
+                            },
+                            <<>>}};
+                1 ->
+                    ?assertEqual(<<"wrong_otp">>, maps:get(api_otp, Config)),
+                    {ok,
+                        {401,
+                            #{
+                                <<"www-authenticate">> =>
+                                    <<"Bearer realm=\"hex\", error=\"invalid_totp\"">>
+                            },
+                            <<>>}};
+                _ ->
+                    ?assertEqual(<<"correct_otp">>, maps:get(api_otp, Config)),
+                    {ok, {200, #{}, <<"success">>}}
+            end
+        end
+    ),
+    ?assertEqual({ok, {200, #{}, <<"success">>}}, Result),
+    ?assertEqual(3, counters:get(CallCount, 1)),
+    ok.
+
+with_api_otp_cancelled_test(_Config) ->
+    %% Test OTP cancellation returns error
+    Now = erlang:system_time(second),
+    Callbacks = make_callbacks(#{
+        oauth_tokens =>
+            {ok, #{
+                access_token => <<"token">>,
+                expires_at => Now + 3600
+            }},
+        prompt_otp => fun(_Msg) -> cancelled end
+    }),
+
+    Result = hex_cli_auth:with_api(
+        Callbacks,
+        write,
+        ?CONFIG,
+        fun(_Cfg) ->
+            {ok,
+                {401,
+                    #{
+                        <<"www-authenticate">> =>
+                            <<"Bearer realm=\"hex\", error=\"totp_required\"">>
+                    },
+                    <<>>}}
+        end
+    ),
+    ?assertEqual({error, {auth_error, otp_cancelled}}, Result),
+    ok.
+
+with_api_otp_max_retries_test(_Config) ->
+    %% Test OTP max retries returns error
+    Now = erlang:system_time(second),
+    Callbacks = make_callbacks(#{
+        oauth_tokens =>
+            {ok, #{
+                access_token => <<"token">>,
+                expires_at => Now + 3600
+            }},
+        prompt_otp => fun(_Msg) -> {ok, <<"wrong_otp">>} end
+    }),
+
+    Result = hex_cli_auth:with_api(
+        Callbacks,
+        write,
+        ?CONFIG,
+        fun(_Cfg) ->
+            {ok,
+                {401,
+                    #{<<"www-authenticate">> => <<"Bearer realm=\"hex\", error=\"invalid_totp\"">>},
+                    <<>>}}
+        end
+    ),
+    ?assertEqual({error, {auth_error, otp_max_retries}}, Result),
+    ok.
+
+%%====================================================================
+%% Test Cases - with_api token refresh on 401
+%%====================================================================
+
+with_api_token_expired_refresh_test(_Config) ->
+    %% Test token refresh when server returns token_expired
+    Now = erlang:system_time(second),
+    Self = self(),
+    Callbacks = make_callbacks(#{
+        oauth_tokens =>
+            {ok, #{
+                access_token => <<"initial_token">>,
+                refresh_token => <<"refresh_token">>,
+                %% Within EXPIRY_BUFFER_SECONDS, will trigger refresh
+                expires_at => Now + 100
+            }},
+        persist_oauth_tokens => fun(_Scope, Access, Refresh, Expires) ->
+            Self ! {persisted, Access, Refresh, Expires},
+            ok
+        end
+    }),
+
+    CallCount = counters:new(1, []),
+    Result = hex_cli_auth:with_api(
+        Callbacks,
+        write,
+        ?CONFIG,
+        fun(Config) ->
+            Count = counters:get(CallCount, 1),
+            counters:add(CallCount, 1, 1),
+            ApiKey = maps:get(api_key, Config),
+            case Count of
+                0 ->
+                    %% First call gets refreshed token (initial was within expiry buffer)
+                    ?assertMatch(<<"Bearer ", _/binary>>, ApiKey),
+                    ?assertNotEqual(<<"Bearer initial_token">>, ApiKey),
+                    {ok,
+                        {401,
+                            #{
+                                <<"www-authenticate">> =>
+                                    <<"Bearer realm=\"hex\", error=\"token_expired\"">>
+                            },
+                            <<>>}};
+                _ ->
+                    %% Second refresh after 401
+                    ?assertMatch(<<"Bearer ", _/binary>>, ApiKey),
+                    {ok, {200, #{}, <<"success">>}}
+            end
+        end
+    ),
+    ?assertEqual({ok, {200, #{}, <<"success">>}}, Result),
+    ?assertEqual(2, counters:get(CallCount, 1)),
+
+    %% Verify tokens were persisted (at least once for initial refresh)
+    receive
+        {persisted, _NewAccess, _NewRefresh, _NewExpires} -> ok
+    after 100 ->
+        error(token_not_persisted)
+    end,
+    ok.
+
+%%====================================================================
+%% Test Cases - with_api (wrapper behavior)
+%%====================================================================
+
+with_api_optional_test(_Config) ->
+    %% Test optional => true allows requests without auth
+    Callbacks = make_callbacks(#{oauth_tokens => error}),
+
+    %% Function is called without api_key
+    Result = hex_cli_auth:with_api(
+        Callbacks,
+        read,
+        ?CONFIG,
+        fun(Config) -> maps:get(api_key, Config, undefined) end,
+        [{optional, true}]
+    ),
+    ?assertEqual(undefined, Result),
+    ok.
+
+with_api_auth_inline_test(_Config) ->
+    %% Test auth_inline => false returns error instead of prompting
+    Callbacks = make_callbacks(#{oauth_tokens => error}),
+
+    Result = hex_cli_auth:with_api(
+        Callbacks,
+        read,
+        ?CONFIG,
+        fun(_) -> error(should_not_be_called) end,
+        [{optional, false}, {auth_inline, false}]
+    ),
+    ?assertEqual({error, {auth_error, no_credentials}}, Result),
+    ok.
+
+with_api_device_auth_test(_Config) ->
+    %% Test device auth flow when should_authenticate returns true
+    Self = self(),
+    Callbacks = make_callbacks(#{
+        oauth_tokens => error,
+        should_authenticate => fun(no_credentials) -> true end,
+        persist_oauth_tokens => fun(Scope, Access, Refresh, Expires) ->
+            Self ! {persisted, Scope, Access, Refresh, Expires},
+            ok
+        end
+    }),
+
+    %% Queue success response for device auth polling
+    AccessToken = <<"device_token">>,
+    RefreshToken = <<"device_refresh">>,
+    SuccessPayload = #{
+        <<"access_token">> => AccessToken,
+        <<"refresh_token">> => RefreshToken,
+        <<"token_type">> => <<"Bearer">>,
+        <<"expires_in">> => 3600
+    },
+    Headers = #{<<"content-type">> => <<"application/vnd.hex+erlang; charset=utf-8">>},
+    Self !
+        {hex_http_test, oauth_device_response,
+            {ok, {200, Headers, term_to_binary(SuccessPayload)}}},
+
+    Result = hex_cli_auth:with_api(
+        Callbacks,
+        write,
+        ?CONFIG,
+        fun(Config) -> maps:get(api_key, Config) end,
+        [{oauth_open_browser, false}]
+    ),
+    ?assertEqual(<<"Bearer device_token">>, Result),
+
+    %% Verify token was persisted
+    receive
+        {persisted, global, AccessToken, RefreshToken, _} -> ok
+    after 100 ->
+        error(token_not_persisted)
+    end,
+    ok.
+
+%%====================================================================
+%% Test Cases - with_repo (wrapper behavior)
+%%====================================================================
+
+with_repo_optional_test(_Config) ->
+    %% Test that with_repo with optional => true (default) proceeds without auth
+    Callbacks = make_callbacks(#{oauth_tokens => error}),
+
+    Result = hex_cli_auth:with_repo(
+        Callbacks,
+        ?CONFIG#{trusted => false},
+        fun(Config) -> maps:get(repo_key, Config, undefined) end
+    ),
+    ?assertEqual(undefined, Result),
+    ok.
+
+with_repo_trusted_with_auth_test(_Config) ->
+    %% Test with_repo with trusted config and auth_key
+    Callbacks = make_callbacks(#{
+        auth_config => #{<<"hexpm">> => #{auth_key => <<"my_auth_key">>}}
+    }),
+
+    Result = hex_cli_auth:with_repo(
+        Callbacks,
+        ?CONFIG#{trusted => true, oauth_exchange => false},
+        fun(Config) -> maps:get(repo_key, Config) end
+    ),
+    ?assertEqual(<<"my_auth_key">>, Result),
+    ok.
+
+%%====================================================================
+%% Helper Functions
+%%====================================================================
+
+make_callbacks(Opts) ->
+    AuthConfig = maps:get(auth_config, Opts, #{}),
+    PromptOtp = maps:get(prompt_otp, Opts, fun(_) -> cancelled end),
+    ShouldAuthenticate = maps:get(should_authenticate, Opts, fun(_) -> false end),
+    PersistFn = maps:get(persist_oauth_tokens, Opts, fun(_, _, _, _) -> ok end),
+    DefaultGetOAuthTokens = fun() -> maps:get(oauth_tokens, Opts, error) end,
+    GetOAuthTokensFn = maps:get(get_oauth_tokens, Opts, DefaultGetOAuthTokens),
+
+    #{
+        get_auth_config => fun(RepoName) -> maps:get(RepoName, AuthConfig, undefined) end,
+        get_oauth_tokens => GetOAuthTokensFn,
+        persist_oauth_tokens => PersistFn,
+        prompt_otp => PromptOtp,
+        should_authenticate => ShouldAuthenticate,
+        get_client_id => fun() -> <<"test_client">> end
+    }.

--- a/test/hex_cli_auth_SUITE.erl
+++ b/test/hex_cli_auth_SUITE.erl
@@ -65,7 +65,11 @@ all() ->
 
         %% with_repo tests - wrapper behavior
         with_repo_optional_test,
-        with_repo_trusted_with_auth_test
+        with_repo_trusted_with_auth_test,
+        with_repo_optional_token_refresh_failed_test,
+
+        %% concurrency tests
+        resolve_oauth_token_concurrent_refresh_serialized_test
     ].
 
 %%====================================================================
@@ -818,6 +822,102 @@ with_repo_trusted_with_auth_test(_Config) ->
         fun(Config) -> maps:get(repo_key, Config) end
     ),
     ?assertEqual(<<"my_auth_key">>, Result),
+    ok.
+
+with_repo_optional_token_refresh_failed_test(_Config) ->
+    %% When resolve_repo_auth fails with token_refresh_failed and optional is true,
+    %% fall back to executing the request without credentials.
+    Now = erlang:system_time(second),
+    Callbacks = make_callbacks(#{
+        oauth_tokens =>
+            {ok, #{
+                access_token => <<"expired_token">>,
+                %% Expired with no refresh_token => token_refresh_failed immediately
+                expires_at => Now - 100
+            }}
+    }),
+
+    Result = hex_cli_auth:with_repo(
+        Callbacks,
+        ?CONFIG#{trusted => true},
+        fun(Config) -> maps:get(repo_key, Config, undefined) end
+    ),
+    ?assertEqual(undefined, Result),
+    ok.
+
+%%====================================================================
+%% Test Cases - Concurrency
+%%====================================================================
+
+resolve_oauth_token_concurrent_refresh_serialized_test(_Config) ->
+    %% Two concurrent calls to resolve_api_auth with an expired token should
+    %% serialize: only one refresh happens; the second waits and then re-reads
+    %% the (now-fresh) token rather than doing a second refresh.
+    Now = erlang:system_time(second),
+    Self = self(),
+    RefreshCount = counters:new(1, [atomics]),
+
+    %% get_oauth_tokens is called by each process; we simulate the token
+    %% being updated after the first refresh by tracking call count.
+    GetOAuthTokensFn = fun() ->
+        Count = counters:get(RefreshCount, 1),
+        case Count of
+            0 ->
+                %% Token is expired — both processes will see this initially
+                {ok, #{
+                    access_token => <<"expired_token">>,
+                    refresh_token => <<"refresh_token">>,
+                    expires_at => Now - 100
+                }};
+            _ ->
+                %% After the first refresh, return a fresh token
+                {ok, #{
+                    access_token => <<"new_token">>,
+                    refresh_token => <<"new_refresh_token">>,
+                    expires_at => Now + 3600
+                }}
+        end
+    end,
+
+    Callbacks = make_callbacks(#{
+        get_oauth_tokens => GetOAuthTokensFn,
+        persist_oauth_tokens => fun(_Scope, _Access, _Refresh, _Expires) ->
+            %% Simulate a slow refresh so the second process must wait
+            timer:sleep(100),
+            counters:add(RefreshCount, 1, 1),
+            Self ! refreshed,
+            ok
+        end
+    }),
+
+    %% Spawn two concurrent callers
+    spawn(fun() ->
+        Result = hex_cli_auth:resolve_api_auth(Callbacks, read, ?CONFIG),
+        Self ! {result1, Result}
+    end),
+    spawn(fun() ->
+        Result = hex_cli_auth:resolve_api_auth(Callbacks, read, ?CONFIG),
+        Self ! {result2, Result}
+    end),
+
+    receive
+        {result1, R1} -> ok
+    end,
+    receive
+        {result2, R2} -> ok
+    end,
+
+    %% Both should succeed with a bearer token
+    ?assertMatch({ok, <<"Bearer ", _/binary>>, _}, R1),
+    ?assertMatch({ok, <<"Bearer ", _/binary>>, _}, R2),
+
+    %% The token refresh should have happened exactly once
+    ?assertEqual(1, counters:get(RefreshCount, 1)),
+
+    receive
+        refreshed -> ok
+    after 0 -> ok
+    end,
     ok.
 
 %%====================================================================

--- a/test/hex_cli_auth_SUITE.erl
+++ b/test/hex_cli_auth_SUITE.erl
@@ -78,33 +78,33 @@ all() ->
 
 resolve_api_auth_config_passthrough_test(_Config) ->
     %% When api_key is already in config, it should be used directly
-    Callbacks = make_callbacks(#{}),
-    ConfigWithKey = ?CONFIG#{api_key => <<"config_api_key">>},
+    Config = config_with_callbacks(#{}),
+    ConfigWithKey = Config#{api_key => <<"config_api_key">>},
 
-    {ok, ApiKey, AuthContext} = hex_cli_auth:resolve_api_auth(Callbacks, read, ConfigWithKey),
+    {ok, ApiKey, AuthContext} = hex_cli_auth:resolve_api_auth(read, ConfigWithKey),
     ?assertEqual(<<"config_api_key">>, ApiKey),
     ?assertEqual(#{source => config, has_refresh_token => false}, AuthContext),
     ok.
 
 resolve_api_auth_per_repo_test(_Config) ->
     %% Test per-repo api_key from callback
-    Callbacks = make_callbacks(#{
+    Config = config_with_callbacks(#{
         auth_config => #{<<"hexpm">> => #{api_key => <<"repo_api_key">>}}
     }),
 
-    {ok, ApiKey, AuthContext} = hex_cli_auth:resolve_api_auth(Callbacks, write, ?CONFIG),
+    {ok, ApiKey, AuthContext} = hex_cli_auth:resolve_api_auth(write, Config),
     ?assertEqual(<<"repo_api_key">>, ApiKey),
     ?assertEqual(#{source => config, has_refresh_token => false}, AuthContext),
     ok.
 
 resolve_api_auth_parent_repo_test(_Config) ->
     %% Test parent repo fallback for "hexpm:org" repos
-    Callbacks = make_callbacks(#{
+    Config = config_with_callbacks(#{
         auth_config => #{<<"hexpm">> => #{api_key => <<"parent_api_key">>}}
     }),
 
     {ok, ApiKey, _} = hex_cli_auth:resolve_api_auth(
-        Callbacks, write, ?CONFIG#{repo_name => <<"hexpm:myorg">>}
+        write, Config#{repo_name => <<"hexpm:myorg">>}
     ),
     ?assertEqual(<<"parent_api_key">>, ApiKey),
     ok.
@@ -112,7 +112,7 @@ resolve_api_auth_parent_repo_test(_Config) ->
 resolve_api_auth_oauth_test(_Config) ->
     %% Test OAuth token fallback with valid token
     Now = erlang:system_time(second),
-    Callbacks = make_callbacks(#{
+    Config = config_with_callbacks(#{
         oauth_tokens =>
             {ok, #{
                 access_token => <<"oauth_token">>,
@@ -121,7 +121,7 @@ resolve_api_auth_oauth_test(_Config) ->
             }}
     }),
 
-    {ok, ApiKey, AuthContext} = hex_cli_auth:resolve_api_auth(Callbacks, read, ?CONFIG),
+    {ok, ApiKey, AuthContext} = hex_cli_auth:resolve_api_auth(read, Config),
     ?assertEqual(<<"Bearer oauth_token">>, ApiKey),
     ?assertEqual(#{source => oauth, has_refresh_token => true}, AuthContext),
     ok.
@@ -130,7 +130,7 @@ resolve_api_auth_oauth_expired_refresh_test(_Config) ->
     %% Test OAuth token refresh when expired
     Now = erlang:system_time(second),
     Self = self(),
-    Callbacks = make_callbacks(#{
+    Config = config_with_callbacks(#{
         oauth_tokens =>
             {ok, #{
                 access_token => <<"expired_token">>,
@@ -144,7 +144,7 @@ resolve_api_auth_oauth_expired_refresh_test(_Config) ->
         end
     }),
 
-    {ok, ApiKey, AuthContext} = hex_cli_auth:resolve_api_auth(Callbacks, read, ?CONFIG),
+    {ok, ApiKey, AuthContext} = hex_cli_auth:resolve_api_auth(read, Config),
     %% Should have refreshed and got a new token
     ?assertMatch(<<"Bearer ", _/binary>>, ApiKey),
     ?assertEqual(#{source => oauth, has_refresh_token => true}, AuthContext),
@@ -160,7 +160,7 @@ resolve_api_auth_oauth_expired_refresh_test(_Config) ->
 resolve_api_auth_oauth_no_refresh_token_test(_Config) ->
     %% Test OAuth token without refresh token
     Now = erlang:system_time(second),
-    Callbacks = make_callbacks(#{
+    Config = config_with_callbacks(#{
         oauth_tokens =>
             {ok, #{
                 access_token => <<"oauth_token">>,
@@ -168,19 +168,19 @@ resolve_api_auth_oauth_no_refresh_token_test(_Config) ->
             }}
     }),
 
-    {ok, ApiKey, AuthContext} = hex_cli_auth:resolve_api_auth(Callbacks, read, ?CONFIG),
+    {ok, ApiKey, AuthContext} = hex_cli_auth:resolve_api_auth(read, Config),
     ?assertEqual(<<"Bearer oauth_token">>, ApiKey),
     ?assertEqual(#{source => oauth, has_refresh_token => false}, AuthContext),
     ok.
 
 resolve_api_auth_no_auth_test(_Config) ->
     %% Test when no auth is available
-    Callbacks = make_callbacks(#{
+    Config = config_with_callbacks(#{
         auth_config => #{},
         oauth_tokens => error
     }),
 
-    Result = hex_cli_auth:resolve_api_auth(Callbacks, read, ?CONFIG),
+    Result = hex_cli_auth:resolve_api_auth(read, Config),
     ?assertEqual({error, no_auth}, Result),
     ok.
 
@@ -190,51 +190,51 @@ resolve_api_auth_no_auth_test(_Config) ->
 
 resolve_repo_auth_config_passthrough_test(_Config) ->
     %% When repo_key is already in config, it should be used directly
-    Callbacks = make_callbacks(#{}),
-    ConfigWithKey = ?CONFIG#{repo_key => <<"config_repo_key">>},
+    Config = config_with_callbacks(#{}),
+    ConfigWithKey = Config#{repo_key => <<"config_repo_key">>},
 
-    {ok, RepoKey, AuthContext} = hex_cli_auth:resolve_repo_auth(Callbacks, ConfigWithKey),
+    {ok, RepoKey, AuthContext} = hex_cli_auth:resolve_repo_auth(ConfigWithKey),
     ?assertEqual(<<"config_repo_key">>, RepoKey),
     ?assertEqual(#{source => config, has_refresh_token => false}, AuthContext),
     ok.
 
 resolve_repo_auth_callback_repo_key_test(_Config) ->
     %% Test repo_key from get_auth_config callback
-    Callbacks = make_callbacks(#{
+    Config = config_with_callbacks(#{
         auth_config => #{<<"hexpm">> => #{repo_key => <<"callback_repo_key">>}}
     }),
 
-    {ok, RepoKey, _} = hex_cli_auth:resolve_repo_auth(Callbacks, ?CONFIG#{trusted => true}),
+    {ok, RepoKey, _} = hex_cli_auth:resolve_repo_auth(Config#{trusted => true}),
     ?assertEqual(<<"callback_repo_key">>, RepoKey),
     ok.
 
 resolve_repo_auth_trusted_auth_key_test(_Config) ->
     %% Test trusted + auth_key (no oauth_exchange) uses auth_key directly
-    Callbacks = make_callbacks(#{
+    Config = config_with_callbacks(#{
         auth_config => #{<<"hexpm">> => #{auth_key => <<"auth_key_value">>}}
     }),
 
-    Config = ?CONFIG#{trusted => true, oauth_exchange => false},
-    {ok, RepoKey, _} = hex_cli_auth:resolve_repo_auth(Callbacks, Config),
+    {ok, RepoKey, _} = hex_cli_auth:resolve_repo_auth(
+        Config#{trusted => true, oauth_exchange => false}
+    ),
     ?assertEqual(<<"auth_key_value">>, RepoKey),
     ok.
 
 resolve_repo_auth_untrusted_ignores_auth_key_test(_Config) ->
     %% Test untrusted config ignores auth_key even when present
-    Callbacks = make_callbacks(#{
+    Config = config_with_callbacks(#{
         auth_config => #{<<"hexpm">> => #{auth_key => <<"auth_key_value">>}},
         oauth_tokens => error
     }),
 
-    Config = ?CONFIG#{trusted => false},
-    Result = hex_cli_auth:resolve_repo_auth(Callbacks, Config),
+    Result = hex_cli_auth:resolve_repo_auth(Config#{trusted => false}),
     ?assertEqual(no_auth, Result),
     ok.
 
 resolve_repo_auth_oauth_fallback_test(_Config) ->
     %% Test fallback to global OAuth when trusted but no auth_key
     Now = erlang:system_time(second),
-    Callbacks = make_callbacks(#{
+    Config = config_with_callbacks(#{
         auth_config => #{},
         oauth_tokens =>
             {ok, #{
@@ -243,27 +243,25 @@ resolve_repo_auth_oauth_fallback_test(_Config) ->
             }}
     }),
 
-    Config = ?CONFIG#{trusted => true},
-    {ok, RepoKey, _} = hex_cli_auth:resolve_repo_auth(Callbacks, Config),
+    {ok, RepoKey, _} = hex_cli_auth:resolve_repo_auth(Config#{trusted => true}),
     ?assertEqual(<<"Bearer global_oauth">>, RepoKey),
     ok.
 
 resolve_repo_auth_no_auth_test(_Config) ->
     %% Test no_auth when untrusted and no credentials
-    Callbacks = make_callbacks(#{
+    Config = config_with_callbacks(#{
         auth_config => #{},
         oauth_tokens => error
     }),
 
-    Config = ?CONFIG#{trusted => false},
-    Result = hex_cli_auth:resolve_repo_auth(Callbacks, Config),
+    Result = hex_cli_auth:resolve_repo_auth(Config#{trusted => false}),
     ?assertEqual(no_auth, Result),
     ok.
 
 resolve_repo_auth_oauth_exchange_new_token_test(_Config) ->
     %% Test oauth_exchange with auth_key but no existing oauth_token
     Self = self(),
-    Callbacks = make_callbacks(#{
+    Config = config_with_callbacks(#{
         auth_config => #{<<"hexpm">> => #{auth_key => <<"my_auth_key">>}},
         persist_oauth_tokens => fun(Scope, Access, _Refresh, Expires) ->
             Self ! {persisted, Scope, Access, Expires},
@@ -271,8 +269,9 @@ resolve_repo_auth_oauth_exchange_new_token_test(_Config) ->
         end
     }),
 
-    Config = ?CONFIG#{trusted => true, oauth_exchange => true},
-    {ok, RepoKey, AuthContext} = hex_cli_auth:resolve_repo_auth(Callbacks, Config),
+    {ok, RepoKey, AuthContext} = hex_cli_auth:resolve_repo_auth(
+        Config#{trusted => true, oauth_exchange => true}
+    ),
     ?assertMatch(<<"Bearer ", _/binary>>, RepoKey),
     ?assertEqual(#{source => oauth, has_refresh_token => false}, AuthContext),
 
@@ -287,7 +286,7 @@ resolve_repo_auth_oauth_exchange_new_token_test(_Config) ->
 resolve_repo_auth_oauth_exchange_existing_valid_test(_Config) ->
     %% Test oauth_exchange with existing valid oauth_token reuses it
     Now = erlang:system_time(second),
-    Callbacks = make_callbacks(#{
+    Config = config_with_callbacks(#{
         auth_config => #{
             <<"hexpm">> => #{
                 auth_key => <<"my_auth_key">>,
@@ -299,8 +298,9 @@ resolve_repo_auth_oauth_exchange_existing_valid_test(_Config) ->
         }
     }),
 
-    Config = ?CONFIG#{trusted => true, oauth_exchange => true},
-    {ok, RepoKey, _} = hex_cli_auth:resolve_repo_auth(Callbacks, Config),
+    {ok, RepoKey, _} = hex_cli_auth:resolve_repo_auth(
+        Config#{trusted => true, oauth_exchange => true}
+    ),
     ?assertEqual(<<"Bearer existing_token">>, RepoKey),
     ok.
 
@@ -308,7 +308,7 @@ resolve_repo_auth_oauth_exchange_existing_expired_test(_Config) ->
     %% Test oauth_exchange with expired oauth_token re-exchanges
     Now = erlang:system_time(second),
     Self = self(),
-    Callbacks = make_callbacks(#{
+    Config = config_with_callbacks(#{
         auth_config => #{
             <<"hexpm">> => #{
                 auth_key => <<"my_auth_key">>,
@@ -324,8 +324,9 @@ resolve_repo_auth_oauth_exchange_existing_expired_test(_Config) ->
         end
     }),
 
-    Config = ?CONFIG#{trusted => true, oauth_exchange => true},
-    {ok, RepoKey, _} = hex_cli_auth:resolve_repo_auth(Callbacks, Config),
+    {ok, RepoKey, _} = hex_cli_auth:resolve_repo_auth(
+        Config#{trusted => true, oauth_exchange => true}
+    ),
     ?assertMatch(<<"Bearer ", _/binary>>, RepoKey),
     ?assertNotEqual(<<"Bearer expired_token">>, RepoKey),
 
@@ -339,12 +340,13 @@ resolve_repo_auth_oauth_exchange_existing_expired_test(_Config) ->
 
 resolve_repo_auth_parent_repo_auth_key_test(_Config) ->
     %% Test trusted org repo falls back to parent repo auth_key
-    Callbacks = make_callbacks(#{
+    Config = config_with_callbacks(#{
         auth_config => #{<<"hexpm">> => #{auth_key => <<"parent_auth_key">>}}
     }),
 
-    Config = ?CONFIG#{repo_name => <<"hexpm:myorg">>, trusted => true, oauth_exchange => false},
-    {ok, RepoKey, _} = hex_cli_auth:resolve_repo_auth(Callbacks, Config),
+    {ok, RepoKey, _} = hex_cli_auth:resolve_repo_auth(
+        Config#{repo_name => <<"hexpm:myorg">>, trusted => true, oauth_exchange => false}
+    ),
     ?assertEqual(<<"parent_auth_key">>, RepoKey),
     ok.
 
@@ -355,7 +357,7 @@ resolve_repo_auth_parent_repo_auth_key_test(_Config) ->
 with_api_otp_required_test(_Config) ->
     %% Test OTP prompt when server returns otp_required
     Now = erlang:system_time(second),
-    Callbacks = make_callbacks(#{
+    Config = config_with_callbacks(#{
         oauth_tokens =>
             {ok, #{
                 access_token => <<"token">>,
@@ -366,10 +368,9 @@ with_api_otp_required_test(_Config) ->
 
     CallCount = counters:new(1, []),
     Result = hex_cli_auth:with_api(
-        Callbacks,
         write,
-        ?CONFIG,
-        fun(Config) ->
+        Config,
+        fun(Cfg) ->
             Count = counters:get(CallCount, 1),
             counters:add(CallCount, 1, 1),
             case Count of
@@ -384,7 +385,7 @@ with_api_otp_required_test(_Config) ->
                             <<>>}};
                 _ ->
                     %% Second call: should have OTP, return success
-                    ?assertEqual(<<"123456">>, maps:get(api_otp, Config)),
+                    ?assertEqual(<<"123456">>, maps:get(api_otp, Cfg)),
                     {ok, {200, #{}, <<"success">>}}
             end
         end
@@ -397,7 +398,7 @@ with_api_otp_invalid_retry_test(_Config) ->
     %% Test OTP retry when server returns invalid_totp
     Now = erlang:system_time(second),
     OtpAttempts = counters:new(1, []),
-    Callbacks = make_callbacks(#{
+    Config = config_with_callbacks(#{
         oauth_tokens =>
             {ok, #{
                 access_token => <<"token">>,
@@ -415,10 +416,9 @@ with_api_otp_invalid_retry_test(_Config) ->
 
     CallCount = counters:new(1, []),
     Result = hex_cli_auth:with_api(
-        Callbacks,
         write,
-        ?CONFIG,
-        fun(Config) ->
+        Config,
+        fun(Cfg) ->
             Count = counters:get(CallCount, 1),
             counters:add(CallCount, 1, 1),
             case Count of
@@ -431,7 +431,7 @@ with_api_otp_invalid_retry_test(_Config) ->
                             },
                             <<>>}};
                 1 ->
-                    ?assertEqual(<<"wrong_otp">>, maps:get(api_otp, Config)),
+                    ?assertEqual(<<"wrong_otp">>, maps:get(api_otp, Cfg)),
                     {ok,
                         {401,
                             #{
@@ -440,7 +440,7 @@ with_api_otp_invalid_retry_test(_Config) ->
                             },
                             <<>>}};
                 _ ->
-                    ?assertEqual(<<"correct_otp">>, maps:get(api_otp, Config)),
+                    ?assertEqual(<<"correct_otp">>, maps:get(api_otp, Cfg)),
                     {ok, {200, #{}, <<"success">>}}
             end
         end
@@ -452,7 +452,7 @@ with_api_otp_invalid_retry_test(_Config) ->
 with_api_otp_cancelled_test(_Config) ->
     %% Test OTP cancellation returns error
     Now = erlang:system_time(second),
-    Callbacks = make_callbacks(#{
+    Config = config_with_callbacks(#{
         oauth_tokens =>
             {ok, #{
                 access_token => <<"token">>,
@@ -462,9 +462,8 @@ with_api_otp_cancelled_test(_Config) ->
     }),
 
     Result = hex_cli_auth:with_api(
-        Callbacks,
         write,
-        ?CONFIG,
+        Config,
         fun(_Cfg) ->
             {ok,
                 {401,
@@ -481,7 +480,7 @@ with_api_otp_cancelled_test(_Config) ->
 with_api_otp_max_retries_test(_Config) ->
     %% Test OTP max retries returns error
     Now = erlang:system_time(second),
-    Callbacks = make_callbacks(#{
+    Config = config_with_callbacks(#{
         oauth_tokens =>
             {ok, #{
                 access_token => <<"token">>,
@@ -491,9 +490,8 @@ with_api_otp_max_retries_test(_Config) ->
     }),
 
     Result = hex_cli_auth:with_api(
-        Callbacks,
         write,
-        ?CONFIG,
+        Config,
         fun(_Cfg) ->
             {ok,
                 {401,
@@ -512,7 +510,7 @@ with_api_token_expired_refresh_test(_Config) ->
     %% Test token refresh when server returns token_expired
     Now = erlang:system_time(second),
     Self = self(),
-    Callbacks = make_callbacks(#{
+    Config = config_with_callbacks(#{
         oauth_tokens =>
             {ok, #{
                 access_token => <<"initial_token">>,
@@ -528,13 +526,12 @@ with_api_token_expired_refresh_test(_Config) ->
 
     CallCount = counters:new(1, []),
     Result = hex_cli_auth:with_api(
-        Callbacks,
         write,
-        ?CONFIG,
-        fun(Config) ->
+        Config,
+        fun(Cfg) ->
             Count = counters:get(CallCount, 1),
             counters:add(CallCount, 1, 1),
-            ApiKey = maps:get(api_key, Config),
+            ApiKey = maps:get(api_key, Cfg),
             case Count of
                 0 ->
                     %% First call gets refreshed token (initial was within expiry buffer)
@@ -574,7 +571,7 @@ with_api_token_expired_reauth_yes_test(_Config) ->
     %% device auth flow is triggered and the operation retried.
     Self = self(),
     Now = erlang:system_time(second),
-    Callbacks = make_callbacks(#{
+    Config = config_with_callbacks(#{
         oauth_tokens =>
             {ok, #{
                 access_token => <<"initial_token">>,
@@ -608,11 +605,10 @@ with_api_token_expired_reauth_yes_test(_Config) ->
             {ok, {200, Headers, term_to_binary(SuccessPayload)}}},
 
     Result = hex_cli_auth:with_api(
-        Callbacks,
         write,
-        ?CONFIG,
-        fun(Config) ->
-            ApiKey = maps:get(api_key, Config),
+        Config,
+        fun(Cfg) ->
+            ApiKey = maps:get(api_key, Cfg),
             case ApiKey of
                 <<"Bearer initial_token">> ->
                     {ok,
@@ -648,7 +644,7 @@ with_api_token_expired_reauth_no_test(_Config) ->
     %% returns auth_declined error.
     Self = self(),
     Now = erlang:system_time(second),
-    Callbacks = make_callbacks(#{
+    Config = config_with_callbacks(#{
         oauth_tokens =>
             {ok, #{
                 access_token => <<"initial_token">>,
@@ -663,9 +659,8 @@ with_api_token_expired_reauth_no_test(_Config) ->
     }),
 
     Result = hex_cli_auth:with_api(
-        Callbacks,
         write,
-        ?CONFIG,
+        Config,
         fun(_) ->
             {ok,
                 {401,
@@ -689,7 +684,7 @@ with_api_token_expired_reauth_inline_false_test(_Config) ->
     %% When auth_inline is false, token refresh failure returns error directly
     %% without prompting the user.
     Now = erlang:system_time(second),
-    Callbacks = make_callbacks(#{
+    Config = config_with_callbacks(#{
         oauth_tokens =>
             {ok, #{
                 access_token => <<"initial_token">>,
@@ -701,9 +696,8 @@ with_api_token_expired_reauth_inline_false_test(_Config) ->
     }),
 
     Result = hex_cli_auth:with_api(
-        Callbacks,
         write,
-        ?CONFIG,
+        Config,
         fun(_) ->
             {ok,
                 {401,
@@ -724,14 +718,13 @@ with_api_token_expired_reauth_inline_false_test(_Config) ->
 
 with_api_optional_test(_Config) ->
     %% Test optional => true allows requests without auth
-    Callbacks = make_callbacks(#{oauth_tokens => error}),
+    Config = config_with_callbacks(#{oauth_tokens => error}),
 
     %% Function is called without api_key
     Result = hex_cli_auth:with_api(
-        Callbacks,
         read,
-        ?CONFIG,
-        fun(Config) -> maps:get(api_key, Config, undefined) end,
+        Config,
+        fun(Cfg) -> maps:get(api_key, Cfg, undefined) end,
         [{optional, true}]
     ),
     ?assertEqual(undefined, Result),
@@ -739,12 +732,11 @@ with_api_optional_test(_Config) ->
 
 with_api_auth_inline_test(_Config) ->
     %% Test auth_inline => false returns error instead of prompting
-    Callbacks = make_callbacks(#{oauth_tokens => error}),
+    Config = config_with_callbacks(#{oauth_tokens => error}),
 
     Result = hex_cli_auth:with_api(
-        Callbacks,
         read,
-        ?CONFIG,
+        Config,
         fun(_) -> error(should_not_be_called) end,
         [{optional, false}, {auth_inline, false}]
     ),
@@ -754,7 +746,7 @@ with_api_auth_inline_test(_Config) ->
 with_api_device_auth_test(_Config) ->
     %% Test device auth flow when should_authenticate returns true
     Self = self(),
-    Callbacks = make_callbacks(#{
+    Config = config_with_callbacks(#{
         oauth_tokens => error,
         should_authenticate => fun(no_credentials) -> true end,
         persist_oauth_tokens => fun(Scope, Access, Refresh, Expires) ->
@@ -778,10 +770,9 @@ with_api_device_auth_test(_Config) ->
             {ok, {200, Headers, term_to_binary(SuccessPayload)}}},
 
     Result = hex_cli_auth:with_api(
-        Callbacks,
         write,
-        ?CONFIG,
-        fun(Config) -> maps:get(api_key, Config) end,
+        Config,
+        fun(Cfg) -> maps:get(api_key, Cfg) end,
         [{oauth_open_browser, false}]
     ),
     ?assertEqual(<<"Bearer device_token">>, Result),
@@ -800,26 +791,24 @@ with_api_device_auth_test(_Config) ->
 
 with_repo_optional_test(_Config) ->
     %% Test that with_repo with optional => true (default) proceeds without auth
-    Callbacks = make_callbacks(#{oauth_tokens => error}),
+    Config = config_with_callbacks(#{oauth_tokens => error}),
 
     Result = hex_cli_auth:with_repo(
-        Callbacks,
-        ?CONFIG#{trusted => false},
-        fun(Config) -> maps:get(repo_key, Config, undefined) end
+        Config#{trusted => false},
+        fun(Cfg) -> maps:get(repo_key, Cfg, undefined) end
     ),
     ?assertEqual(undefined, Result),
     ok.
 
 with_repo_trusted_with_auth_test(_Config) ->
     %% Test with_repo with trusted config and auth_key
-    Callbacks = make_callbacks(#{
+    Config = config_with_callbacks(#{
         auth_config => #{<<"hexpm">> => #{auth_key => <<"my_auth_key">>}}
     }),
 
     Result = hex_cli_auth:with_repo(
-        Callbacks,
-        ?CONFIG#{trusted => true, oauth_exchange => false},
-        fun(Config) -> maps:get(repo_key, Config) end
+        Config#{trusted => true, oauth_exchange => false},
+        fun(Cfg) -> maps:get(repo_key, Cfg) end
     ),
     ?assertEqual(<<"my_auth_key">>, Result),
     ok.
@@ -828,7 +817,7 @@ with_repo_optional_token_refresh_failed_test(_Config) ->
     %% When resolve_repo_auth fails with token_refresh_failed and optional is true,
     %% fall back to executing the request without credentials.
     Now = erlang:system_time(second),
-    Callbacks = make_callbacks(#{
+    Config = config_with_callbacks(#{
         oauth_tokens =>
             {ok, #{
                 access_token => <<"expired_token">>,
@@ -838,9 +827,8 @@ with_repo_optional_token_refresh_failed_test(_Config) ->
     }),
 
     Result = hex_cli_auth:with_repo(
-        Callbacks,
-        ?CONFIG#{trusted => true},
-        fun(Config) -> maps:get(repo_key, Config, undefined) end
+        Config#{trusted => true},
+        fun(Cfg) -> maps:get(repo_key, Cfg, undefined) end
     ),
     ?assertEqual(undefined, Result),
     ok.
@@ -879,7 +867,7 @@ resolve_oauth_token_concurrent_refresh_serialized_test(_Config) ->
         end
     end,
 
-    Callbacks = make_callbacks(#{
+    Config = config_with_callbacks(#{
         get_oauth_tokens => GetOAuthTokensFn,
         persist_oauth_tokens => fun(_Scope, _Access, _Refresh, _Expires) ->
             %% Simulate a slow refresh so the second process must wait
@@ -892,11 +880,11 @@ resolve_oauth_token_concurrent_refresh_serialized_test(_Config) ->
 
     %% Spawn two concurrent callers
     spawn(fun() ->
-        Result = hex_cli_auth:resolve_api_auth(Callbacks, read, ?CONFIG),
+        Result = hex_cli_auth:resolve_api_auth(read, Config),
         Self ! {result1, Result}
     end),
     spawn(fun() ->
-        Result = hex_cli_auth:resolve_api_auth(Callbacks, read, ?CONFIG),
+        Result = hex_cli_auth:resolve_api_auth(read, Config),
         Self ! {result2, Result}
     end),
 
@@ -923,6 +911,9 @@ resolve_oauth_token_concurrent_refresh_serialized_test(_Config) ->
 %%====================================================================
 %% Helper Functions
 %%====================================================================
+
+config_with_callbacks(Opts) ->
+    ?CONFIG#{cli_auth_callbacks => make_callbacks(Opts)}.
 
 make_callbacks(Opts) ->
     AuthConfig = maps:get(auth_config, Opts, #{}),

--- a/test/hex_cli_auth_SUITE.erl
+++ b/test/hex_cli_auth_SUITE.erl
@@ -53,6 +53,11 @@ all() ->
         %% with_api tests - token refresh on 401
         with_api_token_expired_refresh_test,
 
+        %% with_api tests - reauthentication after refresh failure
+        with_api_token_expired_reauth_yes_test,
+        with_api_token_expired_reauth_no_test,
+        with_api_token_expired_reauth_inline_false_test,
+
         %% with_api tests - wrapper behavior
         with_api_optional_test,
         with_api_auth_inline_test,
@@ -554,6 +559,159 @@ with_api_token_expired_refresh_test(_Config) ->
     after 100 ->
         error(token_not_persisted)
     end,
+    ok.
+
+%%====================================================================
+%% Test Cases - with_api reauthentication after refresh failure
+%%====================================================================
+
+with_api_token_expired_reauth_yes_test(_Config) ->
+    %% When token refresh fails and user agrees to re-authenticate,
+    %% device auth flow is triggered and the operation retried.
+    Self = self(),
+    Now = erlang:system_time(second),
+    Callbacks = make_callbacks(#{
+        oauth_tokens =>
+            {ok, #{
+                access_token => <<"initial_token">>,
+                %% No refresh_token; token is valid so it's used, but server
+                %% returns token_expired 401, triggering the reauth path
+                expires_at => Now + 3600
+            }},
+        should_authenticate => fun(token_refresh_failed) ->
+            Self ! prompted,
+            true
+        end,
+        persist_oauth_tokens => fun(Scope, Access, Refresh, Expires) ->
+            Self ! {persisted, Scope, Access, Refresh, Expires},
+            ok
+        end
+    }),
+
+    %% Queue token poll success response (device authorization response is handled
+    %% automatically by hex_http_test; only the poll response needs to be queued)
+    AccessToken = <<"new_device_token">>,
+    RefreshToken = <<"new_refresh_token">>,
+    SuccessPayload = #{
+        <<"access_token">> => AccessToken,
+        <<"refresh_token">> => RefreshToken,
+        <<"token_type">> => <<"Bearer">>,
+        <<"expires_in">> => 3600
+    },
+    Headers = #{<<"content-type">> => <<"application/vnd.hex+erlang; charset=utf-8">>},
+    Self !
+        {hex_http_test, oauth_device_response,
+            {ok, {200, Headers, term_to_binary(SuccessPayload)}}},
+
+    Result = hex_cli_auth:with_api(
+        Callbacks,
+        write,
+        ?CONFIG,
+        fun(Config) ->
+            ApiKey = maps:get(api_key, Config),
+            case ApiKey of
+                <<"Bearer initial_token">> ->
+                    {ok,
+                        {401,
+                            #{
+                                <<"www-authenticate">> =>
+                                    <<"Bearer realm=\"hex\", error=\"token_expired\"">>
+                            },
+                            <<>>}};
+                _ ->
+                    {ok, {200, #{}, ApiKey}}
+            end
+        end,
+        [{oauth_open_browser, false}]
+    ),
+    ?assertEqual({ok, {200, #{}, <<"Bearer new_device_token">>}}, Result),
+
+    receive
+        prompted -> ok
+    after 100 ->
+        error(should_authenticate_not_called)
+    end,
+
+    receive
+        {persisted, global, AccessToken, RefreshToken, _} -> ok
+    after 100 ->
+        error(token_not_persisted)
+    end,
+    ok.
+
+with_api_token_expired_reauth_no_test(_Config) ->
+    %% When token refresh fails and user declines to re-authenticate,
+    %% returns auth_declined error.
+    Self = self(),
+    Now = erlang:system_time(second),
+    Callbacks = make_callbacks(#{
+        oauth_tokens =>
+            {ok, #{
+                access_token => <<"initial_token">>,
+                %% No refresh_token; token is valid so it's used, but server
+                %% returns token_expired 401, triggering the reauth path
+                expires_at => Now + 3600
+            }},
+        should_authenticate => fun(token_refresh_failed) ->
+            Self ! prompted,
+            false
+        end
+    }),
+
+    Result = hex_cli_auth:with_api(
+        Callbacks,
+        write,
+        ?CONFIG,
+        fun(_) ->
+            {ok,
+                {401,
+                    #{
+                        <<"www-authenticate">> =>
+                            <<"Bearer realm=\"hex\", error=\"token_expired\"">>
+                    },
+                    <<>>}}
+        end
+    ),
+    ?assertEqual({error, {auth_error, auth_declined}}, Result),
+
+    receive
+        prompted -> ok
+    after 100 ->
+        error(should_authenticate_not_called)
+    end,
+    ok.
+
+with_api_token_expired_reauth_inline_false_test(_Config) ->
+    %% When auth_inline is false, token refresh failure returns error directly
+    %% without prompting the user.
+    Now = erlang:system_time(second),
+    Callbacks = make_callbacks(#{
+        oauth_tokens =>
+            {ok, #{
+                access_token => <<"initial_token">>,
+                %% No refresh_token; token is valid so it's used, but server
+                %% returns token_expired 401, triggering the reauth path
+                expires_at => Now + 3600
+            }},
+        should_authenticate => fun(_) -> error(should_not_be_called) end
+    }),
+
+    Result = hex_cli_auth:with_api(
+        Callbacks,
+        write,
+        ?CONFIG,
+        fun(_) ->
+            {ok,
+                {401,
+                    #{
+                        <<"www-authenticate">> =>
+                            <<"Bearer realm=\"hex\", error=\"token_expired\"">>
+                    },
+                    <<>>}}
+        end,
+        [{auth_inline, false}]
+    ),
+    ?assertEqual({error, {auth_error, token_refresh_failed}}, Result),
     ok.
 
 %%====================================================================

--- a/test/support/hex_http_test.erl
+++ b/test/support/hex_http_test.erl
@@ -324,7 +324,7 @@ fixture(post, <<?TEST_API_URL, "/oauth/device_authorization">>, _, {_, Body}) ->
         <<"verification_uri">> => <<"https://hex.pm/oauth/device">>,
         <<"verification_uri_complete">> => <<"https://hex.pm/oauth/device?user_code=", UserCode/binary>>,
         <<"expires_in">> => 600,
-        <<"interval">> => 5
+        <<"interval">> => 0
     },
     {ok, {200, api_headers(), term_to_binary(Payload)}};
 
@@ -332,12 +332,17 @@ fixture(post, <<?TEST_API_URL, "/oauth/token">>, _, {_, Body}) ->
     DecodedBody = binary_to_term(Body),
     case maps:get(<<"grant_type">>, DecodedBody) of
         <<"urn:ietf:params:oauth:grant-type:device_code">> ->
-            % Simulate pending authorization
-            ErrorPayload = #{
-                <<"error">> => <<"authorization_pending">>,
-                <<"error_description">> => <<"Authorization pending">>
-            },
-            {ok, {400, api_headers(), term_to_binary(ErrorPayload)}};
+            receive
+                {hex_http_test, oauth_device_response, Response} ->
+                    Response
+            after 0 ->
+                % Default: simulate pending authorization
+                ErrorPayload = #{
+                    <<"error">> => <<"authorization_pending">>,
+                    <<"error_description">> => <<"Authorization pending">>
+                },
+                {ok, {400, api_headers(), term_to_binary(ErrorPayload)}}
+            end;
         <<"urn:ietf:params:oauth:grant-type:token-exchange">> ->
             % Simulate successful token exchange
             AccessToken = base64:encode(crypto:strong_rand_bytes(32)),


### PR DESCRIPTION
Base Module organizing Repo / API Auth Management.

This PR is WIP. I'm exploring how it could look.

Implementation PRs:
* https://github.com/hexpm/hex/pull/1143
* https://github.com/erlang/rebar3/pull/3008
* https://github.com/erlef/rebar3_hex/pull/361