### PR TITLE
Apply optional token_refresh_failed fallback in with_api/4

### DIFF
--- a/src/hex_cli_auth.erl
+++ b/src/hex_cli_auth.erl
@@ -234,6 +234,9 @@ with_api(Permission, BaseConfig, Fun, Opts) ->
         {error, no_auth} ->
             %% auth_inline is false, just return error
             {error, {auth_error, no_credentials}};
+        {error, {auth_error, token_refresh_failed}} when Optional =:= true ->
+            %% Token refresh failed but auth is optional, fall back to no credentials
+            execute_optional_with_retry(BaseConfig, Fun, Opts);
         {error, _} = Error ->
             Error
     end.

--- a/test/hex_cli_auth_SUITE.erl
+++ b/test/hex_cli_auth_SUITE.erl
@@ -60,6 +60,7 @@ all() ->
 
         %% with_api tests - wrapper behavior
         with_api_optional_test,
+        with_api_optional_token_refresh_failed_test,
         with_api_auth_inline_test,
         with_api_device_auth_test,
 
@@ -722,6 +723,28 @@ with_api_optional_test(_Config) ->
     Config = config_with_callbacks(#{oauth_tokens => error}),
 
     %% Function is called without api_key
+    Result = hex_cli_auth:with_api(
+        read,
+        Config,
+        fun(Cfg) -> maps:get(api_key, Cfg, undefined) end,
+        [{optional, true}]
+    ),
+    ?assertEqual(undefined, Result),
+    ok.
+
+with_api_optional_token_refresh_failed_test(_Config) ->
+    %% When resolve_api_auth fails with token_refresh_failed and optional is true,
+    %% fall back to executing the request without credentials.
+    Now = erlang:system_time(second),
+    Config = config_with_callbacks(#{
+        oauth_tokens =>
+            {ok, #{
+                access_token => <<"expired_token">>,
+                %% Expired with no refresh_token => token_refresh_failed immediately
+                expires_at => Now - 100
+            }}
+    }),
+
     Result = hex_cli_auth:with_api(
         read,
         Config,


### PR DESCRIPTION
## Summary

`with_repo/3` falls back to executing without credentials when `resolve_repo_auth` returns `{auth_error, token_refresh_failed}` and `optional` is `true`. `with_api/4` was missing the equivalent handling, so an optional API call would surface the refresh failure as an error instead of proceeding anonymously.

This adds the matching clause to `with_api/4`, placed before the catch-all error clause so non-optional calls still propagate the error.

Addresses https://github.com/hexpm/hex/pull/1143#discussion_r3413651365.